### PR TITLE
Disable centerTeleport key when chat is focused

### DIFF
--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -1288,7 +1288,7 @@ function onKeyUp(e) {
 	if(checkKeyPress(e, keyConfig.cursorRight)) { // arrow right
 		autoArrowKeyMoveStop("right");
 	}
-	if(checkKeyPress(e, keyConfig.centerTeleport)) { // home
+	if(checkKeyPress(e, keyConfig.centerTeleport) && e.target == elm.textInput) { // home
 		w.doGoToCoord(0, 0);
 	}
 }


### PR DESCRIPTION
Fixed: pressing home in a modal window or chat still teleports you to the center.