### PR TITLE
relative path support for module identifiers

### DIFF
--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -3195,7 +3195,7 @@ function executeJS(code) {
 
 var modules = {};
 var isModule = false;
-var modPrefixes = [];
+var modPrefixes = [[]];
 
 function runModule(identifier, code, prefix) {
 	modPrefixes.push(prefix);
@@ -3205,28 +3205,23 @@ function runModule(identifier, code, prefix) {
 
 function normalizeModIdentifer(identifier) {
 	identifier = identifier.toLowerCase();
+	var parts = identifier.split('/');
+	parts = parts.filter(part => part !== '.' && part !== '');
+
+	var result = [...modPrefixes[modPrefixes.length - 1]];
+	for (var i = 0; i < parts.length; ++i) {
+		if (parts[i] === "..") {
+			if (result.length > 0)
+				result.pop();
+		} else {
+			result.push(parts[i]);
+		}
+	}
+
+	identifier = result.join('/');
 	if (/^[\w-]+\/[\w-]+(?:@[\w.-]+)?\/(.+\.js)$/.test(identifier)) {
 		return identifier;
 	}
-
-	if (identifier.startsWith('./') || identifier.startsWith('../')) {
-		var parts = identifier.split('/');
-		var result = [];
-
-		parts = parts.filter(part => part !== '.' && part !== '');
-
-		var modPrefix = modPrefixes[modPrefixes.length - 1];
-			for (var i = 0; i < parts.length; ++i) {
-			if (parts[i] === "..") {
-				if (modPrefix.length > 2)
-					modPrefix.pop();
-			} else {
-				result.push(parts[i]);
-			}
-		}
-
-		return modPrefix.concat(result).join('/');
-    }
 	
 	return null;
 }

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -3204,29 +3204,28 @@ function runModule(identifier, code, prefix) {
 }
 
 function normalizeModIdentifer(identifier) {
-	console.log([modPrefixes, identifier]);
 	identifier = identifier.toLowerCase();
 	if (/^[\w-]+\/[\w-]+(?:@[\w.-]+)?\/(.+\.js)$/.test(identifier)) {
 		return identifier;
 	}
 
 	if (identifier.startsWith('./') || identifier.startsWith('../')) {
-        var parts = identifier.split('/');
-        var result = [];
+		var parts = identifier.split('/');
+		var result = [];
 
 		parts = parts.filter(part => part !== '.' && part !== '');
 
 		var modPrefix = modPrefixes[modPrefixes.length - 1];
-        for (var i = 0; i < parts.length; ++i) {
-            if (parts[i] === "..") {
-                if (modPrefix.length > 2)
-                    modPrefix.pop();
-            } else {
-                result.push(parts[i]);
-            }
-        }
+			for (var i = 0; i < parts.length; ++i) {
+			if (parts[i] === "..") {
+				if (modPrefix.length > 2)
+					modPrefix.pop();
+			} else {
+				result.push(parts[i]);
+			}
+		}
 
-        return modPrefix.concat(result).join('/');
+		return modPrefix.concat(result).join('/');
     }
 	
 	return null;


### PR DESCRIPTION
Allow for relative paths (e.g. `use("../otherfile.js")`) in module identifiers to ease making multi-file projects.