### PR TITLE
Set textColorOverride to 0 when switching to day or night mode

### DIFF
--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6508,6 +6508,7 @@ Object.assign(w, {
 		defaultURLLinkColor = "#1570F0";
 		defaultCoordLinkColor = "#409015";
 		w.nightMode = 1;
+		textColorOverride = 0;
 		if(ignoreUnloadedPattern) {
 			w.nightMode = 2;
 		} else if(!elm.owot.classList.contains("nightmode")) {
@@ -6517,6 +6518,7 @@ Object.assign(w, {
 	},
 	day: function(reloadStyle) {
 		w.nightMode = 0;
+		textColorOverride = 0;
 		defaultURLLinkColor = "#0000FF";
 		defaultCoordLinkColor = "#008000";
 		if(elm.owot.classList.contains("nightmode")) {

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -1,6 +1,6 @@
 ﻿var YourWorld = {
 	Color: window.localStorage ? +localStorage.getItem("color") : 0,
-	BgColor: -1,
+	BgColor: window.localStorage ? +localStorage.getItem("bgColor") : 0,
 	Nickname: state.userModel.username
 };
 
@@ -6850,7 +6850,7 @@ function makeColorModal() {
 		if(!isBg) { // text color
 			color = colorInput.value;
 		} else { // cell color
-			if(!colorInputBg.jscolor.refine) return;
+			colorInputBg.jscolor.importColor();
 			color = colorInputBg.value;
 		}
 		var this_color = 0;
@@ -6865,7 +6865,7 @@ function makeColorModal() {
 			localStorage.setItem("color", this_color);
 		} else {
 			w.changeBgColor(this_color);
-			// we don't need to save the bg color to localStorage (if enabled for this world)
+			localStorage.setItem("bgColor", this_color);
 		}
 	});
 	modal.onClose(function(canceled) {


### PR DESCRIPTION
Sometimes, when the text colors on public, member, and owner protections are different, they do not change to black or white when w.day or w.night respectively are called. This aims to fix that.