### PR TITLE
Turn /stats into a packet

### DIFF
--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -205,8 +205,7 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		[0, "delete", ["id", "timestamp"], "delete a chat message", "1220 1693147307895"], // check for permission
 		[0, "tell", ["id", "message"], "tell someone a secret message", "1220 The coordinates are (392, 392)"],
 		[0, "whoami", null, "display your identity"],
-		[0, "test", null, "preview your appearance"],
-		[0, "stats", null, "view stats of a world"]
+		[0, "test", null, "preview your appearance"]
 
 		// hidden by default
 		// "/search Phrase" (client) -> searches for Phrase within a 25 tile radius
@@ -648,12 +647,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 			idstr += "Chat ID: " + clientId;
 			return serverChatResponse(idstr, location);
 		},
-		stats: function() {
-			var stat = "Stats for world:\n";
-			stat += "Creation date: " + create_date(world.creationDate) + "\n";
-			stat += "View count: " + world.views;
-			return serverChatResponse(stat, location);
-		},
 		delete: async function(id, timestamp) {
 			if(!is_owner && !user.staff) return;
 			id = san_nbr(id);
@@ -767,9 +760,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 				return;
 			case "whoami":
 				com.whoami();
-				return;
-			case "stats":
-				com.stats();
 				return;
 			case "delete":
 				com.delete(commandArgs[1], commandArgs[2]);

--- a/backend/websockets/stats.js
+++ b/backend/websockets/stats.js
@@ -1,0 +1,18 @@
+var utils = require("../utils/utils.js");
+var san_nbr = utils.san_nbr;
+
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var world = ctx.world;
+
+	var res = {
+		kind: "stats",
+		creationDate: world.creationDate,
+		views: world.views
+	};
+
+	if(data.id != void 0) {
+		res.id = san_nbr(data.id);
+	}
+
+	send(res);
+}

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -250,6 +250,15 @@ register_chat_comamnd("clear", function() {
 	}
 }, null, "clear all chat messages locally", null);
 
+register_chat_comamnd("stats", function() {
+	network.stats(function(data) {
+		var stat = "Stats for world:\n";
+		stat += "Creation date: " + convertToDate(data.creationDate) + "\n";
+		stat += "View count: " + data.views;
+		clientChatResponse(stat);
+	});
+}, null, "view stats of a world", null);
+
 function sendChat() {
 	var chatText = elm.chatbar.value;
 	elm.chatbar.value = "";

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6510,7 +6510,18 @@ var network = {
 			maxX: maxX,
 			maxY: maxY
 		});
-	}	
+	},
+	stats: function(callback) {
+		var cb_id = void 0;
+		if(callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "stats",
+			id: cb_id // optional: number
+		});
+	}
 };
 
 Object.assign(w, {
@@ -8013,6 +8024,16 @@ var ws_functions = {
 				break;
 			case "PARAM": // invalid parameters in message
 				break;
+		}
+	},
+	stats: function(data) {
+		w.emit("stats", data);
+		if(data.id) {
+			if(network.callbacks[data.id]) {
+				var cb = network.callbacks[data.id];
+				delete network.callbacks[data.id];
+				cb(data);
+			}
 		}
 	}
 };

--- a/runserver.js
+++ b/runserver.js
@@ -586,7 +586,8 @@ var websockets = {
 	protect: require("./backend/websockets/protect.js"),
 	write: require("./backend/websockets/write.js"),
 	config: require("./backend/websockets/config.js"),
-	boundary: require("./backend/websockets/boundary.js")
+	boundary: require("./backend/websockets/boundary.js"),
+	stats: require("./backend/websockets/stats.js")
 };
 
 var modules = {


### PR DESCRIPTION
Makes /stats usable when chat is disabled and generally easier to use in bots/scripts.