### PR TITLE
Remove greentext from chat

### DIFF
--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -19,7 +19,6 @@ var chatWriteTmpBuffer   = "";
 var defaultChatColor     = window.localStorage ? parseInt(localStorage.getItem("chatcolor")) : null; // 24-bit Uint
 var chatPageUnreadBar    = null;
 var chatGlobalUnreadBar  = null;
-var chatGreentext        = true;
 var chatEmotes           = true;
 var acceptChatDeletions  = true;
 var client_commands      = {}; // deprecated
@@ -761,12 +760,6 @@ function buildChatElement(field, id, type, nickname, message, realUsername, op, 
 	var dateStr = "";
 	if(date) dateStr = convertToDate(date);
 	var pm = dataObj.privateMessage;
-	var isGreen = false;
-
-	if(chatGreentext && message[0] == ">" && !(":;_-".includes(message[1]))) { // exception to some emoticons
-		message = message.substr(1);
-		isGreen = true;
-	}
 
 	if(chatLimitCombChars) {
 		message = filterChatMessage(message);
@@ -878,10 +871,6 @@ function buildChatElement(field, id, type, nickname, message, realUsername, op, 
 		} else if(pm == "from_me") {
 			pmDom.innerText = "Me -> ";
 		}
-	}
-
-	if(isGreen) {
-		message = "<span style=\"color: #789922\">&gt;" + message + "</span>";
 	}
 
 	// parse emoticons


### PR DESCRIPTION
this feature always seemed like it was added to attract more 4chan (or other imageboards) users to owot, and it's obvious just how far-right, racist, LGBTQ-phobic, sexist, etc. those users are and how they think they're superior with their identity-lacking hivemind brains that are stuck with internet terms and behavior straight from 2004
also fp casually asked pinkiepie if he was on board with the idea of adding greentext lmfao