### PR TITLE
Enhance SSL configuration handling in HTTP server setup

### DIFF
--- a/backend/framework/server.js
+++ b/backend/framework/server.js
@@ -5,6 +5,7 @@ const crypto = require("crypto");
 const querystring = require("querystring");
 const isIP = require("net").isIP;
 const zlib = require("zlib");
+const fs = require("fs");
 
 const templates = require("./templates.js");
 const utils = require("../utils/utils.js");
@@ -661,14 +662,24 @@ class HTTPServer {
 
 	setSSLConfig(isEnabled, privkeyPath, certPath, chainPath) {
 		this.sslEnabled = !!isEnabled;
-		if(!isEnabled) return;
-		if(!fs.existsSync(private_key) || !fs.existsSync(cert) || !fs.existsSync(chain)) {
+		if(!this.sslEnabled) return false;
+		try {
+			if(!privkeyPath || !certPath || !chainPath) {
+				this.sslEnabled = false;
+				return false;
+			}
+			if(!fs.existsSync(privkeyPath) || !fs.existsSync(certPath) || !fs.existsSync(chainPath)) {
+				this.sslEnabled = false;
+				return false;
+			}
+			this.sslOptions.key = fs.readFileSync(privkeyPath);
+			this.sslOptions.cert = fs.readFileSync(certPath);
+			this.sslOptions.ca = fs.readFileSync(chainPath);
+			return true;
+		} catch(e) {
 			this.sslEnabled = false;
-			return;
+			return false;
 		}
-		this.sslOptions.key = fs.readFileSync(privkeyPath);
-		this.sslOptions.cert = fs.readFileSync(certPath);
-		this.sslOptions.ca = fs.readFileSync(chainPath);
 	}
 	isSSLEnabled() {
 		return this.sslEnabled;

--- a/runserver.js
+++ b/runserver.js
@@ -844,7 +844,6 @@ async function fetchCloudflareIPs(ip_type) {
 function setupHTTPServer() {
 	httpServer = new serverUtil.HTTPServer(settings.port, global_data);
 
-	// Configure HTTPS if enabled in settings
 	if(settings.ssl_enabled) {
 		var sslConf = settings.ssl || {};
 		var priv = sslConf.private_key;
@@ -1374,7 +1373,9 @@ function setupMonitorServer() {
 			port: settings.monitor.port,
 			ip: settings.monitor.ip,
 			user: settings.monitor.credentials.user,
-			pass: settings.monitor.credentials.pass
+			pass: settings.monitor.credentials.pass,
+			ssl_enabled: settings.ssl_enabled || false,
+			ssl_config: settings.ssl || null
 		}
 	});
 	monitorWorker.on("error", function(e) {

--- a/runserver.js
+++ b/runserver.js
@@ -844,6 +844,20 @@ async function fetchCloudflareIPs(ip_type) {
 function setupHTTPServer() {
 	httpServer = new serverUtil.HTTPServer(settings.port, global_data);
 
+	// Configure HTTPS if enabled in settings
+	if(settings.ssl_enabled) {
+		var sslConf = settings.ssl || {};
+		var priv = sslConf.private_key;
+		var cert = sslConf.cert;
+		var chain = sslConf.chain;
+		var ok = httpServer.setSSLConfig(true, priv, cert, chain);
+		if(!ok) {
+			console.log("SSL configuration failed or files missing. Falling back to HTTP.");
+		} else {
+			console.log("SSL enabled. HTTPS server will be used.");
+		}
+	}
+
 	httpServer.setPageTree(pages);
 	httpServer.setDefaultTemplateData("loginPath", loginPath);
 	httpServer.setDefaultTemplateData("logoutPath", logoutPath);


### PR DESCRIPTION
This pull request introduces support for SSL/TLS (HTTPS) to both the main HTTP server and the monitor server, improving security by allowing encrypted connections when properly configured. The changes include configuration handling, runtime checks for SSL files, and fallback mechanisms to HTTP if SSL setup fails.

**SSL/HTTPS Support and Configuration Handling**

* Added logic to `backend/framework/server.js` for enabling SSL, including runtime checks for certificate files and error handling in the `setSSLConfig` method. The server now only enables SSL if all required files are present and readable, otherwise it falls back to HTTP. 
* Updated `runserver.js` to pass SSL configuration to the HTTP server and monitor server, including checks for SSL enablement and logging for success or failure.

**Monitor Server HTTPS Support**

* Modified `backend/monitor/monitor.js` to support running the monitor server over HTTPS if SSL is enabled and configuration is provided. The server falls back to HTTP if SSL configuration is incomplete or an error occurs, with appropriate logging.