### PR TITLE
Move all commands to the client

### DIFF
--- a/backend/subsystems/chat_mgr.js
+++ b/backend/subsystems/chat_mgr.js
@@ -349,6 +349,8 @@ function unmute(world_id, ip) {
 	}
 }
 
+var tell_blocks = {};
+
 module.exports.retrieveChatHistory = retrieveChatHistory;
 module.exports.add_to_chatlog = add_to_chatlog;
 module.exports.remove_from_chatlog = remove_from_chatlog;
@@ -357,3 +359,4 @@ module.exports.getMuteInfo = getMuteInfo;
 module.exports.mute = mute;
 module.exports.clearMutes = clearMutes;
 module.exports.unmute = unmute;
+module.exports.tell_blocks = tell_blocks;

--- a/backend/subsystems/chat_mgr.js
+++ b/backend/subsystems/chat_mgr.js
@@ -314,7 +314,46 @@ async function chatDatabaseClock(serverExit) {
 	}
 }
 
+var muted_ips_by_world_id = {}; // id 0 = global
+function getMuteInfo(world_id, ip) {
+	var worldChatMutes = muted_ips_by_world_id[world_id];
+
+	if(worldChatMutes) {
+		return worldChatMutes[ip];
+	}
+
+	return null;
+}
+
+function mute(world_id, ip, date) {
+	if(!muted_ips_by_world_id[world_id]) muted_ips_by_world_id[world_id] = {};
+	muted_ips_by_world_id[world_id][ip] = [date];
+}
+
+function clearMutes(world_id) {
+	var cnt = 0;
+
+	if(muted_ips_by_world_id[world_id]) {
+		cnt = Object.keys(muted_ips_by_world_id[world_id]).length;
+		delete muted_ips_by_world_id[world_id];
+	}
+
+	return cnt;
+}
+
+function unmute(world_id, ip) {
+	var worldChatMutes = muted_ips_by_world_id[world_id];
+
+	if(worldChatMutes) {
+		delete worldChatMutes[ip];
+	}
+}
+
 module.exports.retrieveChatHistory = retrieveChatHistory;
 module.exports.add_to_chatlog = add_to_chatlog;
 module.exports.remove_from_chatlog = remove_from_chatlog;
 module.exports.clearChatlog = clearChatlog;
+module.exports.getMuteInfo = getMuteInfo;
+module.exports.mute = mute;
+module.exports.clearMutes = clearMutes;
+module.exports.unmute = unmute;

--- a/backend/utils/utils.js
+++ b/backend/utils/utils.js
@@ -820,6 +820,37 @@ function checkURLParam(mask, url) {
 	return values;
 }
 
+function getClientIPByChatID(server, world_id, id, isGlobal) {
+	var client_ips = server.client_ips;
+
+	if(isGlobal) {
+		// since this is global, there is the potential for duplicate IDs.
+		// pick the one that has chatted the most recently.
+		var latestGCli = null;
+		var latestGCliTime = -1;
+		for(var cw in client_ips) {
+			var worldClients = client_ips[cw];
+			if(worldClients[id]) {
+				var gCli = worldClients[id];
+				if(gCli[3] != -1 && gCli[3] >= latestGCliTime) {
+					latestGCliTime = gCli[3];
+					latestGCli = gCli;
+				}
+			}
+		}
+		if(latestGCli) {
+			return latestGCli[0];
+		}
+	} else {
+		if(client_ips[world_id]) {
+			if(client_ips[world_id][id]) {
+				return client_ips[world_id][id][0];
+			}
+		}
+	}
+	return null;
+}
+
 module.exports = {
 	trimHTML,
 	create_date,
@@ -851,5 +882,6 @@ module.exports = {
 	trimSlash,
 	checkDuplicateCookie,
 	toHex64,
-	toInt64
+	toInt64,
+	getClientIPByChatID
 };

--- a/backend/websockets/block_id.js
+++ b/backend/websockets/block_id.js
@@ -1,0 +1,69 @@
+var utils = require("../utils/utils.js");
+var san_nbr = utils.san_nbr;
+var getClientIPByChatID = utils.getClientIPByChatID;
+
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var world = ctx.world
+	var chat_mgr = server.chat_mgr;
+	var tell_blocks = chat_mgr.tell_blocks;
+
+	var ipHeaderAddr = ws.sdata.ipAddress;
+	var blocks = ws.sdata.chat_blocks;
+
+	var id = san_nbr(data.id);
+	if(id < 0) {
+		if(data.block) {
+			send({
+				success: false,
+				error: "bad_id"
+			});
+		}
+
+		return;
+	}
+
+	var location = "";
+	if(!(data.location == "global" || data.location == "page")) data.location = "page";
+	location = data.location;
+
+	if(data.block) {
+		if ((blocks.id.length + blocks.user.length) >= 1280) {
+			send({
+				success: false,
+				error: "too_many"
+			});
+			return;
+		}
+
+		if (blocks.id.indexOf(id) > -1) return;
+		blocks.id.push(id);
+
+		var blocked_ip = getClientIPByChatID(server, world.id, id, location == "global");
+		if(blocked_ip) {
+			var blist = tell_blocks[ipHeaderAddr];
+			if(!blist) {
+				blist = {};
+				tell_blocks[ipHeaderAddr] = blist;
+			}
+			if(!blist[blocked_ip]) {
+				blist[blocked_ip] = Date.now();
+			}
+		}
+
+		send({
+			success: true
+		});
+	} else {
+		var idx = blocks.id.indexOf(id);
+		if(idx == -1) return;
+		blocks.id.splice(idx, 1);
+
+		var unblocked_ip = getClientIPByChatID(server, world.id, id, location == "global");
+		if(unblocked_ip) {
+			var blist = tell_blocks[ipHeaderAddr];
+			if(blist) {
+				delete blist[unblocked_ip];
+			}
+		}
+	}
+}

--- a/backend/websockets/block_special.js
+++ b/backend/websockets/block_special.js
@@ -1,0 +1,8 @@
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var blocks = ws.sdata.chat_blocks;
+
+	if (typeof data.all == "boolean") blocks.block_all = data.all;
+	if (typeof data.tell == "boolean") blocks.no_tell = data.tell;
+	if (typeof data.anon == "boolean") blocks.no_anon = data.anon;
+	if (typeof data.reg == "boolean") blocks.no_reg = data.reg;
+}

--- a/backend/websockets/block_user.js
+++ b/backend/websockets/block_user.js
@@ -1,0 +1,41 @@
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var blocks = ws.sdata.chat_blocks;
+
+	var username = data.username;
+	if(typeof username != "string" || !username) {
+		send({
+			success: false,
+			error: "bad_username"
+		});
+		return;
+	}
+
+	if(data.block) {
+		if (!/^[^\s\x00-\x20]+$/.test(username)) return;
+
+		// The case-insensitive value to be stored in chat_blocks.
+		var username_value = username.toUpperCase();
+
+		// Ensure maximum block count not exceeded, and check if it already exists.
+		if ((blocks.id.length + blocks.user.length) >= 1280) {
+			send({
+				success: false,
+				error: "too_many"
+			});
+			return;
+		}
+
+		if (blocks.user.indexOf(username_value) > -1) return;
+		blocks.user.push(username_value);
+
+		send({
+			success: true
+		});
+	} else {
+		var username_value = username.toUpperCase();
+
+		var idx = blocks.user.indexOf(username_value);
+		if(idx == -1) return;
+		blocks.user.splice(idx, 1);
+	}
+}

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -76,7 +76,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 	var getServerSetting = server.getServerSetting;
 
 	var add_to_chatlog = chat_mgr.add_to_chatlog;
-	var remove_from_chatlog = chat_mgr.remove_from_chatlog;
 
 	var ipHeaderAddr = ws.sdata.ipAddress;
 	var clientId = ws.sdata.clientId;
@@ -221,7 +220,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		[0, "unblockall", null, "unblock all users", null],
 		[0, "mute", ["id", "seconds", "[h/d/w/m/y]"], "mute a user completely", "1220 9999"], // check for permission
 		[0, "clearmutes", null, "unmute all clients"], // check for permission
-		[0, "delete", ["id", "timestamp"], "delete a chat message", "1220 1693147307895"], // check for permission
 		[0, "tell", ["id", "message"], "tell someone a secret message", "1220 The coordinates are (392, 392)"]
 
 		// hidden by default
@@ -254,7 +252,7 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 			var desc = row[3];
 			var example = row[4];
 
-			if(command == "mute" || command == "clearmutes" || command == "delete") {
+			if(command == "mute" || command == "clearmutes") {
 				if(!user.staff && !is_owner) {
 					continue;
 				}
@@ -643,28 +641,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 			}
 			return serverChatResponse("Unmuted " + cnt + " user(s)", location);
 		},
-		delete: async function(id, timestamp) {
-			if(!is_owner && !user.staff) return;
-			id = san_nbr(id);
-			timestamp = san_nbr(timestamp);
-			var wid = world.id;
-			if(location == "global") {
-				if(!user.staff) {
-					return serverChatResponse("You do not have permission to delete messages on global", location);
-				}
-				wid = 0;
-			}
-			var res = await remove_from_chatlog(wid, id, timestamp);
-			if(res == 0) {
-				return serverChatResponse("No messages deleted", location);
-			}
-			broadcast({
-				kind: "chatdelete",
-				id: id,
-				time: timestamp
-			});
-			return serverChatResponse("Deleted " + res + " message(s)", location);
-		},
 		passive: function(mode) {
 			if(mode == "on") {
 				ws.sdata.passiveCmd = true;
@@ -747,9 +723,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 				return;
 			case "clearmutes":
 				com.clearmutes();
-				return;
-			case "delete":
-				com.delete(commandArgs[1], commandArgs[2]);
 				return;
 			case "passive":
 				com.passive(commandArgs[1]);

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -189,56 +189,7 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		username_to_display = user.display_username;
 	}
 
-	// [rank, name, args, description, example]
-	var command_list = [
-		// general
-		[0, "help", null, "list all commands", null]
-
-		// hidden by default
-		// "/search Phrase" (client) -> searches for Phrase within a 25 tile radius
-		// "/passive on/off" -> disable or enable server responses to commands (e.g. /block)
-	];
-
-	function generate_command_list() {
-		var list = [];
-		for(var i = 0; i < command_list.length; i++) {
-			var command = command_list[i];
-			var rank = command[0];
-			if(rank == 3 && user.operator) list.push(command);
-			if(rank == 2 && user.superuser) list.push(command);
-			if(rank == 1 && user.staff) list.push(command);
-			if(rank == 0) list.push(command);
-		}
-
-		// sort the command list
-		list.sort(function(v1, v2) {
-			return v1[1].localeCompare(v2[1], "en", { sensitivity: "base" });
-		});
-
-		var html = "";
-		html += "Command list:\n";
-		for(var i = 0; i < list.length; i++) {
-			var row = list[i];
-			var command = row[1];
-			var args = row[2];
-			var desc = row[3];
-			var example = row[4];
-
-			var rawArgs = "";
-			var rawExample = "";
-			if(example) rawExample = " (/" + command + " " + example + ")";
-			if(args) rawArgs = " <" + args.join(",") + ">";
-
-			html += `/${command}${rawArgs} -> ${desc}${rawExample}\n`;
-
-		}
-		return html;
-	}
-
 	var com = {
-		help: function(modifier) {
-			return serverChatResponse(generate_command_list(), location);
-		},
 		passive: function(mode) {
 			if(mode == "on") {
 				ws.sdata.passiveCmd = true;
@@ -289,9 +240,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		var staff = user.staff;
 
 		switch(commandType) {
-			case "help":
-				com.help();
-				return;
 			case "passive":
 				com.passive(commandArgs[1]);
 				return;

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -74,7 +74,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 	var broadcastMonitorEvent = server.broadcastMonitorEvent;
 	var loadPlugin = server.loadPlugin;
 	var getServerSetting = server.getServerSetting;
-	var getServerUptime = server.getServerUptime;
 
 	var add_to_chatlog = chat_mgr.add_to_chatlog;
 	var remove_from_chatlog = chat_mgr.remove_from_chatlog;
@@ -207,9 +206,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 
 	// [rank, name, args, description, example]
 	var command_list = [
-		// operator
-		[3, "uptime", null, "get uptime of server", null],
-
 		// superuser
 		[2, "worlds", null, "list all worlds", null],
 
@@ -228,7 +224,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		[0, "clearmutes", null, "unmute all clients"], // check for permission
 		[0, "delete", ["id", "timestamp"], "delete a chat message", "1220 1693147307895"], // check for permission
 		[0, "tell", ["id", "message"], "tell someone a secret message", "1220 The coordinates are (392, 392)"],
-		[0, "whoami", null, "display your identity"],
 		[0, "test", null, "preview your appearance"]
 
 		// hidden by default
@@ -454,9 +449,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 			}
 			serverChatResponse("Cleared all blocks", location);
 		},
-		uptime: function() {
-			serverChatResponse("Server uptime: " + calculateTimeDiff(getServerUptime()), location);
-		},
 		tell: function(id, message) {
 			id += "";
 			message += "";
@@ -653,23 +645,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 			}
 			return serverChatResponse("Unmuted " + cnt + " user(s)", location);
 		},
-		whoami: function() {
-			var idstr = "Who Am I:\n";
-			var user_login = "(anonymous)";
-			var user_disp = "(anonymous)";
-			if(user.authenticated) {
-				user_disp = username_to_display;
-				if(accountSystem == "uvias") {
-					user_login = user.username;
-				} else {
-					user_login = user_disp;
-				}
-			}
-			idstr += "Login username: " + user_login + "\n";
-			idstr += "Display username: " + user_disp + "\n";
-			idstr += "Chat ID: " + clientId;
-			return serverChatResponse(idstr, location);
-		},
 		delete: async function(id, timestamp) {
 			if(!is_owner && !user.staff) return;
 			id = san_nbr(id);
@@ -751,9 +726,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 			case "help":
 				com.help();
 				return;
-			case "uptime":
-				com.uptime();
-				return;
 			case "block":
 				com.block(commandArgs[1]);
 				return;
@@ -780,9 +752,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 				return;
 			case "clearmutes":
 				com.clearmutes();
-				return;
-			case "whoami":
-				com.whoami();
 				return;
 			case "delete":
 				com.delete(commandArgs[1], commandArgs[2]);

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -139,7 +139,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 	}
 
 	var isMuted = false;
-	var isTestMessage = false;
 	var muteInfo = null;
 	var worldChatMutes = blocked_ips_by_world_id[world.id];
 	if(location == "global") {
@@ -223,8 +222,7 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		[0, "mute", ["id", "seconds", "[h/d/w/m/y]"], "mute a user completely", "1220 9999"], // check for permission
 		[0, "clearmutes", null, "unmute all clients"], // check for permission
 		[0, "delete", ["id", "timestamp"], "delete a chat message", "1220 1693147307895"], // check for permission
-		[0, "tell", ["id", "message"], "tell someone a secret message", "1220 The coordinates are (392, 392)"],
-		[0, "test", null, "preview your appearance"]
+		[0, "tell", ["id", "message"], "tell someone a secret message", "1220 The coordinates are (392, 392)"]
 
 		// hidden by default
 		// "/search Phrase" (client) -> searches for Phrase within a 25 tile radius
@@ -673,9 +671,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 			} else if(mode == "off") {
 				ws.sdata.passiveCmd = false;
 			}
-		},
-		test: function() {
-			isTestMessage = true;
 		}
 	}
 
@@ -759,9 +754,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 			case "passive":
 				com.passive(commandArgs[1]);
 				return;
-			case "test":
-				com.test();
-				break;
 			default:
 				serverChatResponse("Invalid command: " + msg);
 		}
@@ -849,11 +841,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		clientId,
 		username: user.authenticated ? username_to_display.toUpperCase() : null
 	};
-
-	if(isTestMessage) {
-		websocketChatData.message = "This message is visible to only you.";
-		send(websocketChatData);
-	}
 
 	if(!isCommand) {
 		if(clientIpObj && location == "global") {

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -65,7 +65,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 	var db_chat = server.db_chat;
 	var ws_broadcast = server.ws_broadcast; // site-wide broadcast
 	var chat_mgr = server.chat_mgr;
-	var topActiveWorlds = server.topActiveWorlds;
 	var wss = server.wss;
 	var ranks_cache = server.ranks_cache;
 	var accountSystem = server.accountSystem;
@@ -204,9 +203,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 
 	// [rank, name, args, description, example]
 	var command_list = [
-		// superuser
-		[2, "worlds", null, "list all worlds", null],
-
 		// staff
 		[1, "channel", null, "get info about a chat channel"],
 
@@ -299,23 +295,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 	}
 
 	var com = {
-		worlds: function() {
-			var topCount = 1000;
-			var lst = topActiveWorlds(topCount);
-			var worldList = "";
-			for(var i = 0; i < lst.length; i++) {
-				var row = lst[i];
-				if(row[1] == "") {
-					row[1] = "(main)"
-				} else {
-					row[1] = "/" + row[1];
-				}
-				worldList += "-> " + row[1] + " [" + row[0] + "]";
-				if(i != lst.length - 1) worldList += "\n";
-			}
-			serverChatResponse("Currently loaded worlds (top " + topCount + "):\n" + worldList, location);
-			return;
-		},
 		help: function(modifier) {
 			return serverChatResponse(generate_command_list(), location);
 		},
@@ -691,9 +670,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		var staff = user.staff;
 
 		switch(commandType) {
-			case "worlds":
-				if(superuser) com.worlds();
-				return;
 			case "help":
 				com.help();
 				return;

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -62,7 +62,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 	var world = ctx.world;
 
 	var db = server.db;
-	var db_chat = server.db_chat;
 	var ws_broadcast = server.ws_broadcast; // site-wide broadcast
 	var chat_mgr = server.chat_mgr;
 	var wss = server.wss;
@@ -203,9 +202,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 
 	// [rank, name, args, description, example]
 	var command_list = [
-		// staff
-		[1, "channel", null, "get info about a chat channel"],
-
 		// general
 		[0, "help", null, "list all commands", null],
 		
@@ -533,32 +529,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 			}
 			broadcastMonitorEvent("TellSpam", "Tell from " + clientId + " (" + ipHeaderAddr + ") to " + id + ", first 4 chars: [" + message.slice(0, 4) + "]");
 		},
-		channel: async function() {
-			if(!user.staff) return;
-			var worldId = world.id;
-			if(location == "global") worldId = 0;
-			var channels = await db_chat.all("SELECT * FROM channels WHERE world_id=?", worldId);
-			var count = channels.length;
-			var infoLog = "Found " + count + " channel(s) for this world:\n";
-			for(var i = 0; i < count; i++) {
-				var ch = channels[i];
-				var name = ch.name;
-				var desc = ch.description;
-				var date = ch.date_created;
-				infoLog += "Name: " + name + "\n";
-				infoLog += "Desc: " + desc + "\n";
-				infoLog += "Created: " + create_date(date) + "\n";
-				infoLog += "----------------\n";
-			}
-			var def = await db_chat.get("SELECT * FROM default_channels WHERE world_id=?", worldId);
-			if(def && def.channel_id) {
-				def = def.channel_id;
-			} else {
-				def = "<none>";
-			}
-			infoLog += "Default channel id: " + def;
-			return serverChatResponse(infoLog, location);
-		},
 		mute: function(id, time, flag) {
 			if(!is_owner && !user.staff) return;
 			id = san_nbr(id);
@@ -690,9 +660,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 				return;
 			case "tell":
 				com.tell(commandArgs[1], commandArgs.slice(2).join(" "));
-				return;
-			case "channel":
-				com.channel();
 				return;
 			case "mute":
 				com.mute(commandArgs[1], commandArgs[2], commandArgs[3]);

--- a/backend/websockets/chat_channel.js
+++ b/backend/websockets/chat_channel.js
@@ -1,0 +1,39 @@
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var user = ctx.user;
+	var world = ctx.world;
+	var db_chat = server.db_chat;
+
+	var location = "";
+	if(!(data.location == "global" || data.location == "page")) data.location = "page";
+	location = data.location;
+
+	if(!user.staff) return;
+
+	var worldId = world.id;
+	if(location == "global") worldId = 0;
+
+	var res = {
+		channels: [],
+		default_channel: null
+	};
+
+	var channels = await db_chat.all("SELECT * FROM channels WHERE world_id=?", worldId);
+	var count = channels.length;
+
+	for(var i = 0; i < count; i++) {
+		var ch = channels[i];
+
+		res.channels.push({
+			name: ch.name,
+			description: ch.description,
+			date_created: ch.date_created
+		});
+	}
+
+	var def = await db_chat.get("SELECT * FROM default_channels WHERE world_id=?", worldId);
+	if(def && def.channel_id) {
+		res.default_channel = def.channel_id;
+	}
+
+	send(res);
+}

--- a/backend/websockets/chat_delete_req.js
+++ b/backend/websockets/chat_delete_req.js
@@ -1,0 +1,55 @@
+var utils = require("../utils/utils.js");
+var san_nbr = utils.san_nbr;
+
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var user = ctx.user;
+	var world = ctx.world;
+	var is_owner = world.ownerId == user.id;
+	var chat_mgr = server.chat_mgr;
+	var remove_from_chatlog = chat_mgr.remove_from_chatlog;
+
+	if(!is_owner && !user.staff) {
+		send({
+			success: false,
+			error: "no_perm"
+		});
+		return;
+	}
+
+	var id = san_nbr(data.id);
+	var timestamp = san_nbr(data.timestamp);
+	var wid = world.id;
+
+	var location = "";
+	if(!(data.location == "global" || data.location == "page")) data.location = "page";
+	location = data.location;
+
+	if(location == "global") {
+		if(!user.staff) {
+			send({
+				success: false,
+				error: "no_perm"
+			});
+			return;
+		}
+
+		wid = 0;
+	}
+
+	var res = await remove_from_chatlog(wid, id, timestamp);
+
+	send({
+		success: true,
+		count: res
+	});
+
+	if(res == 0) {
+		return;
+	}
+
+	broadcast({
+		kind: "chatdelete",
+		id: id,
+		time: timestamp
+	});
+}

--- a/backend/websockets/chat_test.js
+++ b/backend/websockets/chat_test.js
@@ -1,0 +1,43 @@
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var user = ctx.user;
+	var clientId = ws.sdata.clientId;
+	var ranks_cache = server.ranks_cache;
+	var accountSystem = server.accountSystem;
+
+	var nick = "";
+	if(data.nickname) {
+		nick = data.nickname + "";
+	}
+	if(!user.staff) {
+		nick = nick.slice(0, 40);
+	} else {
+		nick = nick.slice(0, 3030);
+	}
+
+	var username_to_display = user.username;
+	if(accountSystem == "uvias") {
+		username_to_display = user.display_username;
+	}
+
+	var chatData = {
+		kind: "chat",
+		nickname: nick,
+		realUsername: username_to_display,
+		id: clientId,
+		message: "This message is visible to only you.",
+		registered: user.authenticated,
+		location: data.location,
+		op: user.operator,
+		admin: user.superuser,
+		staff: user.staff,
+		color: data.color
+	};
+
+	if(user.authenticated && user.id in ranks_cache.users) {
+		var rank = ranks_cache[ranks_cache.users[user.id]];
+		chatData.rankName = rank.name;
+		chatData.rankColor = rank.chat_color;
+	}
+
+	send(chatData);
+}

--- a/backend/websockets/clear_mutes.js
+++ b/backend/websockets/clear_mutes.js
@@ -1,0 +1,31 @@
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var user = ctx.user;
+	var world = ctx.world;
+	var chat_mgr = server.chat_mgr;
+	var is_owner = world.ownerId == user.id;
+
+	if(!is_owner && !user.staff) {
+		send({
+			success: false,
+			error: "no_perm"
+		});
+		return;
+	}
+
+	var location = "";
+	if(!(data.location == "global" || data.location == "page")) data.location = "page";
+	location = data.location;
+
+	if(location == "global" && !user.staff) {
+		send({
+			success: false,
+			error: "no_perm"
+		});
+		return;
+	}
+
+	send({
+		success: true,
+		count: chat_mgr.clearMutes(location == "global" ? 0 : world.id)
+	});
+}

--- a/backend/websockets/mute.js
+++ b/backend/websockets/mute.js
@@ -1,0 +1,52 @@
+var utils = require("../utils/utils.js");
+var san_nbr = utils.san_nbr;
+var getClientIPByChatID = utils.getClientIPByChatID;
+
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var user = ctx.user;
+	var world = ctx.world;
+	var chat_mgr = server.chat_mgr;
+	var is_owner = world.ownerId == user.id;
+
+	if(!is_owner && !user.staff) {
+		send({
+			success: false,
+			error: "no_perm"
+		});
+		return;
+	}
+
+	var id = san_nbr(data.id);
+	var time = san_nbr(data.time); // in seconds
+
+	var location = "";
+	if(!(data.location == "global" || data.location == "page")) data.location = "page";
+	location = data.location;
+
+	if(location == "global" && !user.staff) {
+		send({
+			success: false,
+			error: "no_perm"
+		});
+		return;
+	}
+
+	var muted_ip = getClientIPByChatID(server, world.id, id, location == "global");
+
+	if(muted_ip) {
+		var muteDate = Date.now() + (time * 1000);
+		var mute_wid = location == "global" ? 0 : world.id;
+
+		chat_mgr.mute(mute_wid, muted_ip, muteDate);
+
+		send({
+			success: true,
+			until: muteDate
+		});
+	} else {
+		send({
+			success: false,
+			error: "not_found"
+		});
+	}
+}

--- a/backend/websockets/unblock_all.js
+++ b/backend/websockets/unblock_all.js
@@ -1,0 +1,19 @@
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var chat_mgr = server.chat_mgr;
+	var ipHeaderAddr = ws.sdata.ipAddress;
+	var tell_blocks = chat_mgr.tell_blocks;
+
+	ws.sdata.chat_blocks.id.splice(0);
+	ws.sdata.chat_blocks.user.splice(0);
+	ws.sdata.chat_blocks.block_all = false;
+	ws.sdata.chat_blocks.no_tell = false;
+	ws.sdata.chat_blocks.no_anon = false;
+	ws.sdata.chat_blocks.no_reg = false;
+
+	var tblocks = tell_blocks[ipHeaderAddr];
+	if(tblocks) {
+		for(var b in tblocks) {
+			delete tblocks[b];
+		}
+	}
+}

--- a/backend/websockets/uptime.js
+++ b/backend/websockets/uptime.js
@@ -1,0 +1,7 @@
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var getServerUptime = server.getServerUptime;
+
+	send({
+		uptime: getServerUptime()
+	});
+}

--- a/backend/websockets/whoami.js
+++ b/backend/websockets/whoami.js
@@ -1,0 +1,21 @@
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var user = ctx.user;
+	var accountSystem = server.accountSystem;
+
+	var res = {
+		user_login: null,
+		user_disp: null
+	};
+
+	if(user.authenticated) {
+		res.user_login = user.username;
+
+		if(accountSystem == "uvias") {
+			res.user_disp = user.display_username;
+		} else {
+			res.user_disp = user.username;
+		}
+	}
+
+	send(res);
+}

--- a/backend/websockets/worlds.js
+++ b/backend/websockets/worlds.js
@@ -1,0 +1,14 @@
+module.exports = async function(ws, data, send, broadcast, server, ctx) {
+	var user = ctx.user;
+	var topActiveWorlds = server.topActiveWorlds;
+
+	if (!user.superuser) return;
+
+	var topCount = 1000;
+	var list = topActiveWorlds(topCount);
+
+	send({
+		topCount,
+		list
+	});
+}

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -273,6 +273,22 @@ register_chat_command("stats", function() {
 	});
 }, null, "view stats of a world", null);
 
+register_chat_command("uptime", function() {
+	network.uptime(function(data) {
+		clientChatResponse("Server uptime: " + calculateTimeDiff(data.uptime));
+	});
+}, null, "get uptime of server", null);
+
+register_chat_command("whoami", function() {
+	network.whoami(function(data) {
+		var idstr = "Who Am I:\n";
+		idstr += "Login username: " + (data.user_login ?? "(anonymous)") + "\n";
+		idstr += "Display username: " + (data.user_disp ?? "(anonymous)") + "\n";
+		idstr += "Chat ID: " + w.clientId;
+		clientChatResponse(idstr);
+	});
+}, null, "display your identity", null);
+
 function sendChat() {
 	var chatText = elm.chatbar.value;
 	elm.chatbar.value = "";

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -340,6 +340,24 @@ register_chat_command("worlds", function() {
 	});
 }, null, "list all worlds", null);
 
+register_chat_command("channel", function() {
+	var location = selectedChatTab == 0 ? "page" : "global";
+
+	network.chat_channel(location, function(data) {
+		var infoLog = "Found " + data.channels.length + " channel(s) for this world:\n";
+		for(var i = 0; i < data.channels.length; i++) {
+			var ch = data.channels[i];
+			infoLog += "Name: " + ch.name + "\n";
+			infoLog += "Desc: " + ch.description + "\n";
+			infoLog += "Created: " + convertToDate(ch.date_created) + "\n";
+			infoLog += "----------------\n";
+		}
+
+		infoLog += "Default channel id: " + (data.default_channel ?? "<none>");
+		clientChatResponse(infoLog);
+	});
+}, null, "get info about a chat channel", null);
+
 function sendChat() {
 	var chatText = elm.chatbar.value;
 	elm.chatbar.value = "";

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -127,8 +127,10 @@ function api_chat_send(message, opts) {
 		args.shift();
 		if(client_commands.hasOwnProperty(command)) {
 			client_commands[command](args);
-			return;
+		} else {
+			clientChatResponse("Invalid command: " + message);
 		}
+		return;
 	}
 
 	network.chat(message, location, nick, chatColor, customMeta, opts.privateMessageTo);

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -131,7 +131,7 @@ function api_chat_send(message, opts) {
 		}
 	}
 
-	network.chat(message, location, nick, chatColor, customMeta);
+	network.chat(message, location, nick, chatColor, customMeta, opts.privateMessageTo);
 }
 
 function clientChatResponse(message) {
@@ -407,6 +407,21 @@ register_chat_command("clearmutes", function() {
 		}
 	});
 }, null, "unmute all clients", null);
+
+register_chat_command("tell", function(args) {
+	var id = args[0];
+	var msg = args.slice(1).join(" ");
+
+	var opts = {
+		privateMessageTo: id
+	};
+
+	if(defaultChatColor != null) {
+		opts.color = "#" + ("00000" + defaultChatColor.toString(16)).slice(-6);
+	}
+
+	api_chat_send(msg, opts);
+}, ["id", "message"], "tell someone a secret message", "1220 The coordinates are (392, 392)");
 
 function sendChat() {
 	var chatText = elm.chatbar.value;

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -358,6 +358,56 @@ register_chat_command("channel", function() {
 	});
 }, null, "get info about a chat channel", null);
 
+register_chat_command("mute", function(args) {
+	var id = Number(args[0]);
+	var seconds = Number(args[1]);
+	var flag = args[2];
+	var location = selectedChatTab == 0 ? "page" : "global";
+
+	var timeSuffixMap = {
+		"h": 3600,
+		"d": 86400,
+		"w": 86400*7,
+		"m": 86400*30,
+		"y": 31556925.216 //average year length
+	};
+
+	if(flag in timeSuffixMap) {
+		seconds *= timeSuffixMap[flag];
+	} else {
+		if(flag) { //invalid flag
+			clientChatResponse("Invalid flag used for muting, must be h, d, w, m, or y.");
+			return;
+		}
+	}
+
+	network.mute(id, seconds, location, function(data) {
+		if(data.success) {
+			clientChatResponse("Muted client until " + convertToDate(data.until));
+		} else {
+			if(data.error == "no_perm") {
+				clientChatResponse("You do not have permission to mute here");
+			} else if(data.error == "not_found") {
+				clientChatResponse("Client not found");
+			}
+		}
+	});
+}, ["id", "seconds", "[h/d/w/m/y]"], "mute a user completely", "1220 9999");
+
+register_chat_command("clearmutes", function() {
+	var location = selectedChatTab == 0 ? "page" : "global";
+
+	network.clear_mutes(location, function(data) {
+		if(data.success) {
+			clientChatResponse("Unmuted " + data.count + " user(s)");
+		} else {
+			if(data.error == "no_perm") {
+				clientChatResponse("You do not have permission to unmute here");
+			}
+		}
+	});
+}, null, "unmute all clients", null);
+
 function sendChat() {
 	var chatText = elm.chatbar.value;
 	elm.chatbar.value = "";

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -423,6 +423,100 @@ register_chat_command("tell", function(args) {
 	api_chat_send(msg, opts);
 }, ["id", "message"], "tell someone a secret message", "1220 The coordinates are (392, 392)");
 
+register_chat_command("block", function(args) {
+	var id = args[0];
+	var location = selectedChatTab == 0 ? "page" : "global";
+
+	switch (id) {
+	case "*":
+		network.block_special(true, null, null, null);
+		clientChatResponse("Blocked all messages");
+		break;
+	case "tell":
+		network.block_special(null, true, null, null);
+		clientChatResponse("Blocked private messages");
+		break;
+	case "anon":
+		network.block_special(null, null, true, null);
+		clientChatResponse("Blocked messages from anonymous users");
+		break;
+	case "reg":
+		network.block_special(null, null, null, true);
+		clientChatResponse("Blocked messages from registered users");
+		break;
+	default:
+		id = Number(id);
+		network.block_id(id, location, true, function(data) {
+			if(data.success) {
+				clientChatResponse("Blocked chats from ID: " + id);
+			} else {
+				if(data.error == "too_many") {
+					clientChatResponse("Too many blocked IDs/users");
+				} else if(data.error == "bad_id") {
+					clientChatResponse("Invalid ID");
+				}
+			}
+		});
+	}
+}, ["id"], "block someone by id", "1220");
+
+register_chat_command("unblock", function(args) {
+	var id = args[0];
+	var location = selectedChatTab == 0 ? "page" : "global";
+
+	switch (id) {
+	case "*":
+		network.block_special(false, null, null, null);
+		clientChatResponse("Unblocked all messages");
+		break;
+	case "tell":
+		network.block_special(null, false, null, null);
+		clientChatResponse("Unblocked private messages");
+		break;
+	case "anon":
+		network.block_special(null, null, false, null);
+		clientChatResponse("Unblocked messages from anonymous users");
+		break;
+	case "reg":
+		network.block_special(null, null, null, false);
+		clientChatResponse("Unblocked messages from registered users");
+		break;
+	default:
+		id = Number(id);
+		network.block_id(id, location, false);
+		clientChatResponse("Unblocked chats from ID: " + id);
+	}
+
+}, ["id"], "unblock someone by id", "1220");
+
+register_chat_command("blockuser", function(args) {
+	var username = args[0];
+
+	network.block_user(username, true, function(data) {
+		if(data.success) {
+			clientChatResponse("Blocked chats from user: " + username);
+		} else {
+			if(data.error == "too_many") {
+				clientChatResponse("Too many blocked IDs/users");
+			} else if(data.error == "bad_username") {
+				clientChatResponse("Invalid username");
+			}
+		}
+	});
+}, ["username"], "block someone by username", "JohnDoe");
+
+register_chat_command("unblockuser", function(args) {
+	var username = args[0];
+
+	network.block_user(username, false);
+	clientChatResponse("Unblocked chats from user: " + username);
+}, ["username"], "unblock someone by username", "JohnDoe");
+
+register_chat_command("unblockall", function(args) {
+	network.unblock_all();
+	clientChatResponse("Cleared all blocks");
+}, null, "unblock all users", null);
+
 function sendChat() {
 	var chatText = elm.chatbar.value;
 	elm.chatbar.value = "";

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -289,6 +289,20 @@ register_chat_command("whoami", function() {
 	});
 }, null, "display your identity", null);
 
+register_chat_command("test", function() {
+	var location = selectedChatTab == 0 ? "page" : "global";
+	var nickname = YourWorld.Nickname || state.userModel.username;
+
+	var color;
+	if(!YourWorld.Color) {
+		color = assignColor(nickname);
+	} else {
+		color = "#" + ("00000" + YourWorld.Color.toString(16)).slice(-6);
+	}
+
+	network.chat_test(location, nickname, color);
+}, null, "preview your appearance", null);
+
 function sendChat() {
 	var chatText = elm.chatbar.value;
 	elm.chatbar.value = "";

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -323,6 +323,23 @@ register_chat_command("delete", function(args) {
 	});
 }, ["id", "timestamp"], "delete a chat message", "1220 1693147307895");
 
+register_chat_command("worlds", function() {
+	network.worlds(function(data) {
+		var worldList = "";
+		for(var i = 0; i < data.list.length; i++) {
+			var row = data.list[i];
+			if(row[1] == "") {
+				row[1] = "(main)"
+			} else {
+				row[1] = "/" + row[1];
+			}
+			worldList += "-> " + row[1] + " [" + row[0] + "]";
+			if(i != data.list.length - 1) worldList += "\n";
+		}
+		clientChatResponse("Currently loaded worlds (top " + data.topCount + "):\n" + worldList);
+	});
+}, null, "list all worlds", null);
+
 function sendChat() {
 	var chatText = elm.chatbar.value;
 	elm.chatbar.value = "";

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -103,12 +103,15 @@ function api_chat_send(message, opts) {
 	message = message.trim();
 	if(!message.length) return;
 	message = message.slice(0, msgLim);
-	chatWriteHistory.push(message);
-	if(chatWriteHistory.length > chatWriteHistoryMax) {
-		chatWriteHistory.shift();
+
+	if (!opts.privateMessageTo) {
+		chatWriteHistory.push(message);
+		if(chatWriteHistory.length > chatWriteHistoryMax) {
+			chatWriteHistory.shift();
+		}
+		chatWriteHistoryIdx = -1;
+		chatWriteTmpBuffer = "";
 	}
-	chatWriteHistoryIdx = -1;
-	chatWriteTmpBuffer = "";
 
 	var chatColor;
 	if(!opts.color) {

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -303,6 +303,26 @@ register_chat_command("test", function() {
 	network.chat_test(location, nickname, color);
 }, null, "preview your appearance", null);
 
+register_chat_command("delete", function(args) {
+	var id = Number(args[0]);
+	var timestamp = Number(args[1]);
+	var location = selectedChatTab == 0 ? "page" : "global";
+
+	network.chat_delete_req(id, timestamp, location, function(data) {
+		if(data.success) {
+			if(data.count == 0) {
+				clientChatResponse("No messages deleted");
+			} else {
+				clientChatResponse("Deleted " + data.count + " message(s)");
+			}
+		} else {
+			if(data.error == "no_perm") {
+				clientChatResponse("You do not have permission to delete messages here");
+			}
+		}
+	});
+}, ["id", "timestamp"], "delete a chat message", "1220 1693147307895");
+
 function sendChat() {
 	var chatText = elm.chatbar.value;
 	elm.chatbar.value = "";

--- a/frontend/static/yw/javascript/helpers.js
+++ b/frontend/static/yw/javascript/helpers.js
@@ -780,6 +780,37 @@ function filterAdvancedChars(array, noSurrogates, noCombining) {
 	return array;
 }
 
+function calculateTimeDiff(difference) {
+	var str = "";
+	var days = Math.floor(difference / 86400000);
+	difference -= days * 86400000;
+	var hours = Math.floor(difference / 3600000);
+	difference -= hours * 3600000;
+	var minutes = Math.floor(difference / 60000);
+	difference -= minutes * 60000;
+	var seconds = Math.floor(difference / 1000);
+	difference -= seconds * 1000;
+
+	if(days > 0) {
+		if(str) str += ", ";
+		str += days + " day" + (days != 1 ? "s" : "");
+	}
+	if(hours > 0) {
+		if(str) str += ", ";
+		str += hours + " hour" + (hours != 1 ? "s" : "");
+	}
+	if(minutes > 0) {
+		if(str) str += ", ";
+		str += minutes + " minute" + (minutes != 1 ? "s" : "");
+	}
+	if(seconds > 0) {
+		if(str) str += ", ";
+		str += seconds + " second" + (seconds != 1 ? "s" : "");
+	}
+
+	return str;
+}
+
 if(!HTMLElement.prototype.append) {
 	HTMLElement.prototype.append = function(string) {
 		this.appendChild(document.createTextNode(string));

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6571,6 +6571,14 @@ var network = {
 			kind: "whoami",
 			request: cb_id
 		});
+	},
+	chat_test: function(location, nickname, color) {
+		network.transmit({
+			kind: "chat_test",
+			location,
+			nickname,
+			color
+		});
 	}
 };
 

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6464,14 +6464,15 @@ var network = {
 		}
 		network.transmit(fetchReq);
 	},
-	chat: function(message, location, nickname, color, customMeta) {
+	chat: function(message, location, nickname, color, customMeta, pmTo) {
 		network.transmit({
 			kind: "chat",
 			nickname: nickname,
 			message: message,
 			location: location,
 			color: color,
-			customMeta: customMeta
+			customMeta: customMeta,
+			privateMessageTo: pmTo
 		});
 	},
 	ping: function(callback) {

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6579,6 +6579,20 @@ var network = {
 			nickname,
 			color
 		});
+	},
+	chat_delete_req: function(id, timestamp, location, callback) {
+		var cb_id = void 0;
+		if(callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "chat_delete_req",
+			id,
+			timestamp,
+			location,
+			request: cb_id
+		});
 	}
 };
 
@@ -8120,6 +8134,15 @@ var ws_functions = {
 			}
 		}
 	},
+	chat_delete_req: function(data) {
+		if(data.request) {
+			if(network.callbacks[data.request]) {
+				var cb = network.callbacks[data.request];
+				delete network.callbacks[data.request];
+				cb(data);
+			}
+		}
+	}
 };
 
 function begin() {

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6549,6 +6549,28 @@ var network = {
 			kind: "stats",
 			id: cb_id // optional: number
 		});
+	},
+	uptime: function(callback) {
+		var cb_id = void 0;
+		if(callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "uptime",
+			request: cb_id
+		});
+	},
+	whoami: function(callback) {
+		var cb_id = void 0;
+		if(callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "whoami",
+			request: cb_id
+		});
 	}
 };
 
@@ -8071,7 +8093,25 @@ var ws_functions = {
 				cb(data);
 			}
 		}
-	}
+	},
+	uptime: function(data) {
+		if(data.request) {
+			if(network.callbacks[data.request]) {
+				var cb = network.callbacks[data.request];
+				delete network.callbacks[data.request];
+				cb(data);
+			}
+		}
+	},
+	whoami: function(data) {
+		if(data.request) {
+			if(network.callbacks[data.request]) {
+				var cb = network.callbacks[data.request];
+				delete network.callbacks[data.request];
+				cb(data);
+			}
+		}
+	},
 };
 
 function begin() {

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6593,6 +6593,17 @@ var network = {
 			location,
 			request: cb_id
 		});
+	},
+	worlds: function(callback) {
+		var cb_id = void 0;
+		if(callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "worlds",
+			request: cb_id
+		});
 	}
 };
 
@@ -8135,6 +8146,15 @@ var ws_functions = {
 		}
 	},
 	chat_delete_req: function(data) {
+		if(data.request) {
+			if(network.callbacks[data.request]) {
+				var cb = network.callbacks[data.request];
+				delete network.callbacks[data.request];
+				cb(data);
+			}
+		}
+	},
+	worlds: function(data) {
 		if(data.request) {
 			if(network.callbacks[data.request]) {
 				var cb = network.callbacks[data.request];

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6604,6 +6604,18 @@ var network = {
 			kind: "worlds",
 			request: cb_id
 		});
+	},
+	chat_channel: function(location, callback) {
+		var cb_id = void 0;
+		if(callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "chat_channel",
+			location,
+			request: cb_id
+		});
 	}
 };
 
@@ -8155,6 +8167,15 @@ var ws_functions = {
 		}
 	},
 	worlds: function(data) {
+		if(data.request) {
+			if(network.callbacks[data.request]) {
+				var cb = network.callbacks[data.request];
+				delete network.callbacks[data.request];
+				cb(data);
+			}
+		}
+	},
+	chat_channel: function(data) {
 		if(data.request) {
 			if(network.callbacks[data.request]) {
 				var cb = network.callbacks[data.request];

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6616,6 +6616,32 @@ var network = {
 			location,
 			request: cb_id
 		});
+	},
+	mute: function(id, time, location, callback) {
+		var cb_id = void 0;
+		if(callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "mute",
+			id,
+			time,
+			location,
+			request: cb_id
+		});
+	},
+	clear_mutes: function(location, callback) {
+		var cb_id = void 0;
+		if(callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "clear_mutes",
+			location,
+			request: cb_id
+		});
 	}
 };
 
@@ -8176,6 +8202,24 @@ var ws_functions = {
 		}
 	},
 	chat_channel: function(data) {
+		if(data.request) {
+			if(network.callbacks[data.request]) {
+				var cb = network.callbacks[data.request];
+				delete network.callbacks[data.request];
+				cb(data);
+			}
+		}
+	},
+	mute: function(data) {
+		if(data.request) {
+			if(network.callbacks[data.request]) {
+				var cb = network.callbacks[data.request];
+				delete network.callbacks[data.request];
+				cb(data);
+			}
+		}
+	},
+	clear_mutes: function(data) {
 		if(data.request) {
 			if(network.callbacks[data.request]) {
 				var cb = network.callbacks[data.request];

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -6643,6 +6643,47 @@ var network = {
 			location,
 			request: cb_id
 		});
+	},
+	block_id: function(id, location, block, callback) {
+		var cb_id = void 0;
+		if(block && callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "block_id",
+			id,
+			location,
+			block,
+			request: cb_id
+		});
+	},
+	block_user: function(username, block, callback) {
+		var cb_id = void 0;
+		if(block && callback) {
+			cb_id = network.latestID++;
+			network.callbacks[cb_id] = callback;
+		}
+		network.transmit({
+			kind: "block_user",
+			username,
+			block,
+			request: cb_id
+		});
+	},
+	block_special: function(all, tell, anon, reg) {
+		network.transmit({
+			kind: "block_special",
+			all,
+			tell,
+			anon,
+			reg
+		});
+	},
+	unblock_all: function() {
+		network.transmit({
+			kind: "unblock_all"
+		});
 	}
 };
 
@@ -8221,6 +8262,24 @@ var ws_functions = {
 		}
 	},
 	clear_mutes: function(data) {
+		if(data.request) {
+			if(network.callbacks[data.request]) {
+				var cb = network.callbacks[data.request];
+				delete network.callbacks[data.request];
+				cb(data);
+			}
+		}
+	},
+	block_id: function(data) {
+		if(data.request) {
+			if(network.callbacks[data.request]) {
+				var cb = network.callbacks[data.request];
+				delete network.callbacks[data.request];
+				cb(data);
+			}
+		}
+	},
+	block_user: function(data) {
 		if(data.request) {
 			if(network.callbacks[data.request]) {
 				var cb = network.callbacks[data.request];

--- a/runserver.js
+++ b/runserver.js
@@ -607,7 +607,8 @@ var websockets = {
 	boundary: require("./backend/websockets/boundary.js"),
 	stats: require("./backend/websockets/stats.js"),
 	uptime: require("./backend/websockets/uptime.js"),
-	whoami: require("./backend/websockets/whoami.js")
+	whoami: require("./backend/websockets/whoami.js"),
+	chat_test: require("./backend/websockets/chat_test.js")
 };
 
 var modules = {
@@ -2232,7 +2233,7 @@ async function manageWebsocketConnection(ws, req) {
 		}
 		if(!can_process_req_kind(kindLimits, kind)) return;
 		function send(msg) {
-			msg.kind = kind;
+			if(!msg.kind) msg.kind = kind;
 			if(requestID !== null) msg.request = requestID;
 			send_ws(JSON.stringify(msg));
 		}

--- a/runserver.js
+++ b/runserver.js
@@ -613,7 +613,11 @@ var websockets = {
 	worlds: require("./backend/websockets/worlds.js"),
 	chat_channel: require("./backend/websockets/chat_channel.js"),
 	mute: require("./backend/websockets/mute.js"),
-	clear_mutes: require("./backend/websockets/clear_mutes.js")
+	clear_mutes: require("./backend/websockets/clear_mutes.js"),
+	block_special: require("./backend/websockets/block_special.js"),
+	block_id: require("./backend/websockets/block_id.js"),
+	block_user: require("./backend/websockets/block_user.js"),
+	unblock_all: require("./backend/websockets/unblock_all.js")
 };
 
 var modules = {

--- a/runserver.js
+++ b/runserver.js
@@ -609,7 +609,8 @@ var websockets = {
 	uptime: require("./backend/websockets/uptime.js"),
 	whoami: require("./backend/websockets/whoami.js"),
 	chat_test: require("./backend/websockets/chat_test.js"),
-	chat_delete_req: require("./backend/websockets/chat_delete_req.js")
+	chat_delete_req: require("./backend/websockets/chat_delete_req.js"),
+	worlds: require("./backend/websockets/worlds.js")
 };
 
 var modules = {

--- a/runserver.js
+++ b/runserver.js
@@ -1915,7 +1915,6 @@ async function manageWebsocketConnection(ws, req) {
 		messageBackpressure: 0,
 		receiveContentUpdates: true,
 		descriptiveCmd: false,
-		passiveCmd: false,
 		handleCmdSockets: false,
 		cmdsSentInSecond: 0,
 		lastCmdSecond: 0,

--- a/runserver.js
+++ b/runserver.js
@@ -605,7 +605,9 @@ var websockets = {
 	write: require("./backend/websockets/write.js"),
 	config: require("./backend/websockets/config.js"),
 	boundary: require("./backend/websockets/boundary.js"),
-	stats: require("./backend/websockets/stats.js")
+	stats: require("./backend/websockets/stats.js"),
+	uptime: require("./backend/websockets/uptime.js"),
+	whoami: require("./backend/websockets/whoami.js")
 };
 
 var modules = {

--- a/runserver.js
+++ b/runserver.js
@@ -610,7 +610,8 @@ var websockets = {
 	whoami: require("./backend/websockets/whoami.js"),
 	chat_test: require("./backend/websockets/chat_test.js"),
 	chat_delete_req: require("./backend/websockets/chat_delete_req.js"),
-	worlds: require("./backend/websockets/worlds.js")
+	worlds: require("./backend/websockets/worlds.js"),
+	chat_channel: require("./backend/websockets/chat_channel.js")
 };
 
 var modules = {

--- a/runserver.js
+++ b/runserver.js
@@ -608,7 +608,8 @@ var websockets = {
 	stats: require("./backend/websockets/stats.js"),
 	uptime: require("./backend/websockets/uptime.js"),
 	whoami: require("./backend/websockets/whoami.js"),
-	chat_test: require("./backend/websockets/chat_test.js")
+	chat_test: require("./backend/websockets/chat_test.js"),
+	chat_delete_req: require("./backend/websockets/chat_delete_req.js")
 };
 
 var modules = {

--- a/runserver.js
+++ b/runserver.js
@@ -611,7 +611,9 @@ var websockets = {
 	chat_test: require("./backend/websockets/chat_test.js"),
 	chat_delete_req: require("./backend/websockets/chat_delete_req.js"),
 	worlds: require("./backend/websockets/worlds.js"),
-	chat_channel: require("./backend/websockets/chat_channel.js")
+	chat_channel: require("./backend/websockets/chat_channel.js"),
+	mute: require("./backend/websockets/mute.js"),
+	clear_mutes: require("./backend/websockets/clear_mutes.js")
 };
 
 var modules = {


### PR DESCRIPTION
this should remove redundant code (server side command parsing) and allow scripts to use simple network functions instead of messing with command strings and fishing out responses from chat (like in #46)

also, this will make #111 easier (the server won't have to keep track of lang settings)