### PR TITLE
Add relative coordinate links

### DIFF
--- a/backend/modules/write_links.js
+++ b/backend/modules/write_links.js
@@ -39,6 +39,7 @@ module.exports = async function(data, server, params) {
 	var url = data.url;
 	var link_tileX = san_dp(data.link_tileX);
 	var link_tileY = san_dp(data.link_tileY);
+	var relative = data.relative;
 
 	var ipAddress;
 	var ipAddressVal;
@@ -114,11 +115,9 @@ module.exports = async function(data, server, params) {
 		try {
 			plugin.link({
 				ip: ipAddress,
-				is_owner, is_member,
 				tileX, tileY, charX, charY,
-				type,
-				url, link_tileX, link_tileY,
-				user, world
+				user, world, is_owner, is_member,
+				type, url, link_tileX, link_tileY, relative
 			});
 		} catch(e) {}
 	}
@@ -126,7 +125,7 @@ module.exports = async function(data, server, params) {
 	var resp = await tile_database.write(tile_database.types.link, {
 		tileX, tileY, charX, charY,
 		user, world, is_member, is_owner,
-		type, url, link_tileX, link_tileY,
+		type, url, link_tileX, link_tileY, relative,
 		channel, no_log_edits
 	});
 

--- a/backend/subsystems/tile_database.js
+++ b/backend/subsystems/tile_database.js
@@ -641,6 +641,7 @@ function tileWriteLinks(callID, tile, options) {
 	var url = options.url;
 	var link_tileX = options.link_tileX;
 	var link_tileY = options.link_tileY;
+	var relative = options.relative;
 
 	var index = charY * CONST.tileCols + charX;
 	var char_writability = tile.prop_char[index];
@@ -714,7 +715,8 @@ function tileWriteLinks(callID, tile, options) {
 		cellProps[charY][charX].link = {
 			type: "coord",
 			link_tileY: link_tileY,
-			link_tileX: link_tileX
+			link_tileX: link_tileX,
+			relative: relative
 		}
 	}
 	tile.props_updated = true;
@@ -1420,11 +1422,13 @@ function processTileLinkRequest(call_id, data) {
 					linkArch.link_type = 0;
 					linkArch.link_tileX = null;
 					linkArch.link_tileY = null;
+					linkArch.relative = null;
 					linkArch.url = data.url;
 				} else if(data.type == "coord") {
 					linkArch.link_type = 1;
 					linkArch.link_tileX = data.link_tileX;
 					linkArch.link_tileY = data.link_tileY;
+					linkArch.relative = data.relative;
 					linkArch.url = "";
 				}
 				var editData = "@" + JSON.stringify(linkArch);

--- a/backend/websockets/link.js
+++ b/backend/websockets/link.js
@@ -11,13 +11,14 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 	var url = sData.url;
 	var link_tileX = sData.link_tileX;
 	var link_tileY = sData.link_tileY;
+	var relative = sData.relative;
 
 	var do_link = await modules.write_links({
 		type,
 		tileX, tileY,
 		charX, charY,
 		url,
-		link_tileX, link_tileY
+		link_tileX, link_tileY, relative
 	}, server, {
 		user: ctx.user,
 		channel: ctx.channel,

--- a/frontend/static/yw/javascript/renderer.js
+++ b/frontend/static/yw/javascript/renderer.js
@@ -846,6 +846,8 @@ function renderChar(textRender, offsetX, offsetY, char, color, cellW, cellH, pro
 			linkColor = defaultURLLinkColor;
 		} else if(linkType == "coord") {
 			linkColor = defaultCoordLinkColor;
+		} else if(linkType == "coordr") {
+			linkColor = defaultCoordRelativeLinkColor;
 		} else if(linkType == "note") {
 			isLink = false;
 			isTooltip = true;
@@ -1192,6 +1194,8 @@ function renderContent(textRenderCtx, tileX, tileY, clampW, clampH, offsetX, off
 				cellLinkType = tileColProps.link.type;
 				if(tileColProps.link.type == "url" && tileColProps.link.url.startsWith("note:")) {
 					cellLinkType = "note";
+				} else if(cellLinkType == "coord" && tileColProps.link.relative) {
+					cellLinkType = "coordr";
 				}
 			}
 			var protValue = writability;


### PR DESCRIPTION
There is a new checkbox in the relevant modal to enable relative coordinate links.
The modal's text has been updated to reflect this.
defaultCoordRelativeLinkColor is `#00E000` in day theme and `#50E020` in night theme.
Relative coordinate links in pastes are represented by "C" instead of "c".

<img width="900" height="307" alt="image" src="https://github.com/user-attachments/assets/2f636d81-c3f0-49ab-9eb6-de54d1d7c570" />

<img width="363" height="110" alt="image" src="https://github.com/user-attachments/assets/e5567453-0d56-4c48-b7b5-e4b9e4bc7a46" />
<img width="350" height="96" alt="image" src="https://github.com/user-attachments/assets/30f8b333-3eeb-4aca-9398-5de8ba17e34a" />