### PR TITLE
Fixed possible variable name collision in helpers.js

### DIFF
--- a/frontend/static/yw/javascript/helpers.js
+++ b/frontend/static/yw/javascript/helpers.js
@@ -1,10 +1,10 @@
 var enums = {};
 function makeEnum(vars) {
-	var enums = {};
+	var enumInProgress = {};
 	for(var i = 0; i < vars.length; i++) {
-		enums[vars[i]] = i;
+		enumInProgress[vars[i]] = i;
 	}
-	return enums;
+	return enumInProgress;
 }
 
 enums.edit = makeEnum(["tileY", "tileX", "charY", "charX", "time", "char", "id", "color"]);


### PR DESCRIPTION
The makeEnum function declares another "enums" variable which is a bad idea for code. I renamed it to enumInProgress because the name fits and doesn't collide.
Snippet where bug originally was:
```js
// helpers.js
// line 1
var enums = {};
function makeEnum(vars) {
	var enums = {}; // bug here and every other instance of enums in this function
	for(var i = 0; i < vars.length; i++) {
		enums[vars[i]] = i;
	}
	return enums;
}
```