### PR TITLE
Restrict global chat to authenticated users

### DIFF
--- a/backend/pages/accounts/configure.js
+++ b/backend/pages/accounts/configure.js
@@ -276,6 +276,7 @@ module.exports.GET = async function(req, write, server, ctx, params) {
 		square_chars,
 		no_log_edits: world.opts.noLogEdits,
 		no_chat_global: world.opts.noChatGlobal,
+		no_anon_chat: world.opts.noAnonChat,
 		no_copy: world.opts.noCopy,
 		half_chars,
 		mixed_chars,
@@ -534,6 +535,10 @@ module.exports.POST = async function(req, write, server, ctx) {
 		}
 		if(modifyWorldProp(world, "feature/memberTilesAddRemove", Boolean(membertiles_addremove))) {
 			featureUpdates.push({type: "memberTilesAddRemove", value: Boolean(membertiles_addremove)});
+		}
+		var no_anon_chat = post_data.no_anon_chat == "1";
+		if(modifyWorldProp(world, "opts/noAnonChat", no_anon_chat)) {
+			featureUpdates.push({type: "noAnonChat", value: no_anon_chat});
 		}
 
 		if(featureUpdates.length) {

--- a/backend/pages/admin/administrator.js
+++ b/backend/pages/admin/administrator.js
@@ -86,7 +86,8 @@ module.exports.GET = async function(req, write, server, ctx, params) {
 		custom_ranks,
 		client_version: getClientVersion(),
 		csrftoken,
-		global_chat_enabled: getServerSetting("chatGlobalEnabled") == "1"
+		global_chat_enabled: getServerSetting("chatGlobalEnabled") == "1",
+		global_chat_no_anon: getServerSetting("chatGlobalNoAnon") == "1"
 	};
 
 	write(render("administrator.html", data));
@@ -133,6 +134,14 @@ module.exports.POST = async function(req, write, server, ctx) {
 			}
 		} else {
 			updateServerSetting("chatGlobalEnabled", "0");
+		}
+		if("set_chat_global_no_anon" in post_data) {
+			var isNoAnon = post_data.set_chat_global_no_anon;
+			if(isNoAnon == "on") {
+				updateServerSetting("chatGlobalNoAnon", "1");
+			}
+		} else {
+			updateServerSetting("chatGlobalNoAnon", "0");
 		}
 	}
 	if("announcement" in post_data) {

--- a/backend/pages/world_props.js
+++ b/backend/pages/world_props.js
@@ -63,6 +63,7 @@ module.exports.GET = async function(req, write, server, ctx) {
 			writeInt: world.opts.writeInt,
 			desc: world.opts.desc,
 			noChatGlobal: world.opts.noChatGlobal,
+			noAnonChat: world.opts.noAnonChat,
 			noCopy: world.opts.noCopy,
 			defaultScriptPath: world.opts.defaultScriptPath,
 			colorPalette: world.opts.colorPaletteEnabled ? world.opts.colorPalette : null,

--- a/backend/pages/yourworld.js
+++ b/backend/pages/yourworld.js
@@ -125,6 +125,7 @@ module.exports.GET = async function(req, write, server, ctx, params) {
 				write_interval: write_int,
 				no_copy: world.opts.noCopy,
 				no_chat_global: world.opts.noChatGlobal || !isGlobalEnabled,
+				no_anon_chat: world.opts.noAnonChat,
 				color_palette: world.opts.colorPaletteEnabled ? world.opts.colorPalette : null,
 				bg_color_palette: world.opts.bgColorPaletteEnabled ? world.opts.bgColorPalette : null
 			}

--- a/backend/subsystems/world_mgr.js
+++ b/backend/subsystems/world_mgr.js
@@ -73,6 +73,7 @@ var world_default_props = {
 	square_chars: false,
 	no_log_edits: false,
 	no_chat_global: false,
+	no_anon_chat: false,
 	no_copy: false,
 	half_chars: false,
 	char_rate: "",
@@ -216,6 +217,7 @@ function makeWorldObject() {
 			squareChars: false,
 			noLogEdits: false,
 			noChatGlobal: false,
+			noAnonChat: false,
 			noCopy: false,
 			halfChars: false,
 			charRate: "",
@@ -341,6 +343,7 @@ function loadWorldIntoObject(world, wobj) {
 	wobj.opts.squareChars = getAndProcWorldProp(wprops, "square_chars");
 	wobj.opts.noLogEdits = getAndProcWorldProp(wprops, "no_log_edits");
 	wobj.opts.noChatGlobal = getAndProcWorldProp(wprops, "no_chat_global");
+	wobj.opts.noAnonChat = getAndProcWorldProp(wprops, "no_anon_chat");
 	wobj.opts.noCopy = getAndProcWorldProp(wprops, "no_copy");
 	wobj.opts.halfChars = getAndProcWorldProp(wprops, "half_chars");
 	wobj.opts.charRate = getAndProcWorldProp(wprops, "char_rate");
@@ -502,6 +505,7 @@ async function commitWorld(world) {
 		"opts/squareChars",
 		"opts/noLogEdits",
 		"opts/noChatGlobal",
+		"opts/noAnonChat",
 		"opts/noCopy",
 		"opts/halfChars",
 		"opts/charRate",
@@ -539,6 +543,7 @@ async function commitWorld(world) {
 		square_chars: world.opts.squareChars,
 		no_log_edits: world.opts.noLogEdits,
 		no_chat_global: world.opts.noChatGlobal,
+		no_anon_chat: world.opts.noAnonChat,
 		no_copy: world.opts.noCopy,
 		half_chars: world.opts.halfChars,
 		char_rate: world.opts.charRate,

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -139,6 +139,13 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		return;
 	}
 
+	if(location == "global" && accountSystem == "uvias") {
+		if(typeof user.id !== "string" || !user.id.startsWith("x")) {
+			serverChatResponse("Sign in to send messages in global chat.", location);
+			return;
+		}
+	}
+
 	var isMuted = false;
 	var isTestMessage = false;
 	var muteInfo = null;

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -139,11 +139,11 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		return;
 	}
 
-	if(location == "global" && accountSystem == "uvias") {
-		if(typeof user.id !== "string" || !user.id.startsWith("x")) {
+	if (location == "global" && accountSystem == "uvias") {
+    	if (!user.realUsername || user.realUsername.trim() === "") {
 			serverChatResponse("Sign in to send messages in global chat.", location);
-			return;
-		}
+        	return;
+    	}
 	}
 
 	var isMuted = false;

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -139,8 +139,14 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		return;
 	}
 
-	if (location == "global" && accountSystem == "uvias") {
-    	if (!user.realUsername || user.realUsername.trim() === "") {
+	var username_to_display = user.username;
+	if(accountSystem == "uvias") {
+		username_to_display = user.display_username;
+	}
+	var has_chat_username = typeof username_to_display == "string" && !!username_to_display.trim();
+
+	if(location == "global") {
+		if(!user.authenticated || !has_chat_username) {
 			serverChatResponse("Sign in to send messages in global chat.", location);
         	return;
     	}
@@ -203,11 +209,6 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 
 	if(data.hasOwnProperty("customMeta")) {
 		data.customMeta = sanitizeCustomMeta(data.customMeta);
-	}
-
-	var username_to_display = user.username;
-	if(accountSystem == "uvias") {
-		username_to_display = user.display_username;
 	}
 
 	var chatBlockLimit = 1280;

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -146,10 +146,23 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 	var has_chat_username = typeof username_to_display == "string" && !!username_to_display.trim();
 
 	if(location == "global") {
-		if(!user.authenticated || !has_chat_username) {
+		var chatGlobalNoAnon = getServerSetting("chatGlobalNoAnon") == "1";
+		if(chatGlobalNoAnon && !user.authenticated) {
 			serverChatResponse("Sign in to send messages in global chat.", location);
-        	return;
-    	}
+			return;
+		}
+		if(user.authenticated && !has_chat_username) {
+			serverChatResponse("Your account needs a username to send messages in global chat.", location);
+			return;
+			// I'm not sure if this case can actually happen, but just in case - Alan
+		}
+	} //elseif?
+
+	if(location == "page") {
+		if(world.opts.noAnonChat && !user.authenticated) {
+			serverChatResponse("Sign in to send messages in this world.", location);
+			return;
+		}
 	}
 
 	var isMuted = false;

--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -8366,6 +8366,9 @@ var ws_functions = {
 				case "noCopy":
 					state.worldModel.no_copy = value;
 					break;
+				case "noAnonChat":
+					state.worldModel.no_anon_chat = value;
+					break;
 				case "chat":
 					state.worldModel.chat_permission = value;
 					elm.chatbar.disabled = !Permissions.can_chat(state.userModel, state.worldModel);

--- a/frontend/templates/administrator.html
+++ b/frontend/templates/administrator.html
@@ -302,6 +302,10 @@
 					Global chat enabled:
 					<input type="checkbox" name="set_chat_global_enabled" id="set_chat_global_enabled"{%if global_chat_enabled%} checked{%endif%}>
 				</div>
+				<div>
+					Global chat: prevent anonymous users:
+					<input type="checkbox" name="set_chat_global_no_anon" id="set_chat_global_no_anon"{%if global_chat_no_anon%} checked{%endif%}>
+				</div>
 				<input type="submit" value="Set">
 			</form>
 		</div>

--- a/frontend/templates/configure.html
+++ b/frontend/templates/configure.html
@@ -422,6 +422,15 @@
 						</td>
 					</tr>
 					<tr>
+						<td class="feature_name">No anonymous chat</td>
+						<td>
+							<input type="checkbox" name="no_anon_chat" value="1"{%if no_anon_chat%} checked{%endif%}>
+						</td>
+						<td class="feature_description">
+							Prevent anonymous (unregistered) users from chatting. Registered users can always chat.
+						</td>
+					</tr>
+					<tr>
 						<td class="feature_name">Change text color</td>
 						<td>
 							<select name="color_text">

--- a/runserver.js
+++ b/runserver.js
@@ -115,7 +115,8 @@ var sql_edits_init = "./backend/edits.sql";
 
 var serverSettings = {
 	announcement: "",
-	chatGlobalEnabled: "1"
+	chatGlobalEnabled: "1",
+	chatGlobalNoAnon: "0"
 };
 var serverSettingsStatus = {};
 


### PR DESCRIPTION
This pull request prevents users without accounts from chatting in the global chat.

- cuts down on spam and throwaway messages from anonymous users
- makes moderation significantly easier since every message is tied to an account...
- improves accountability, so users are less likely to abuse global chat
- keeps global chat more stable and usable for actual interaction