### PR TITLE
Fix action:theme confirmation

### DIFF
--- a/frontend/static/yw/javascript/owot.js
+++ b/frontend/static/yw/javascript/owot.js
@@ -3793,9 +3793,13 @@ var actions = {
 	day: (args, coords) => w.day(),
 	theme: (args, coords) => {
 		var charInfo = getCharInfo(coords[0], coords[1], coords[2], coords[3]);
-		var restrict = state.worldModel.name == "" && charInfo.protection == 0;
+		var restrict = isMainPage() && charInfo.protection == 0;
 		if(restrict) {
-			var acpt = confirm("Do you want to perform this action?\n" + string);
+			var argstrings = [];
+			for (let value of Object.entries(args)) {
+				argstrings.push(`${value[0]}: ${value[1]}`);
+			}
+			var acpt = confirm("Do you want to change to this theme?\n" + argstrings.join(', '));
 			if(!acpt) {
 				return false;
 			}


### PR DESCRIPTION
stop lazypasting code paws at you

before:
<img width="560" height="133" alt="image" src="https://github.com/user-attachments/assets/87067726-d3ae-44e4-ac9c-f45e745bed1a" />
after:
<img width="617" height="295" alt="image" src="https://github.com/user-attachments/assets/c379292f-b550-42c7-8000-15f931076703" />
