### PR TITLE
Restrict chat access for accounts under minimum age

### DIFF
--- a/backend/pages/admin/administrator.js
+++ b/backend/pages/admin/administrator.js
@@ -87,7 +87,8 @@ module.exports.GET = async function(req, write, server, ctx, params) {
 		client_version: getClientVersion(),
 		csrftoken,
 		global_chat_enabled: getServerSetting("chatGlobalEnabled") == "1",
-		global_chat_no_anon: getServerSetting("chatGlobalNoAnon") == "1"
+		global_chat_no_anon: getServerSetting("chatGlobalNoAnon") == "1",
+		chat_age_restriction: getServerSetting("chatAgeRestriction")
 	};
 
 	write(render("administrator.html", data));
@@ -142,6 +143,11 @@ module.exports.POST = async function(req, write, server, ctx) {
 			}
 		} else {
 			updateServerSetting("chatGlobalNoAnon", "0");
+		}
+		if("set_chat_age_restriction" in post_data) {
+			var ageRestrictionHours = parseInt(post_data.set_chat_age_restriction);
+			if(isNaN(ageRestrictionHours) || ageRestrictionHours < 0) ageRestrictionHours = 0;
+			updateServerSetting("chatAgeRestriction", ageRestrictionHours.toString());
 		}
 	}
 	if("announcement" in post_data) {

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -170,6 +170,16 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 		return;
 	}
 
+	if(user.authenticated && user.date_joined) {
+		var accountAge = Date.now() - user.date_joined;
+		var minimumAge = 24 * 60 * 60 * 1000; // 24 hours
+		if(accountAge < minimumAge) {
+			var timeRemaining = calculateTimeDiff(minimumAge - accountAge);
+			serverChatResponse("Your account is too new. You must wait " + timeRemaining + " before chatting.", location);
+			return;
+		}
+	}
+
 	var isTestMessage = false;
 
 	var isMuted = (

--- a/backend/websockets/chat.js
+++ b/backend/websockets/chat.js
@@ -171,12 +171,15 @@ module.exports = async function(ws, data, send, broadcast, server, ctx) {
 	}
 
 	if(user.authenticated && user.date_joined) {
-		var accountAge = Date.now() - user.date_joined;
-		var minimumAge = 24 * 60 * 60 * 1000; // 24 hours
-		if(accountAge < minimumAge) {
-			var timeRemaining = calculateTimeDiff(minimumAge - accountAge);
-			serverChatResponse("Your account is too new. You must wait " + timeRemaining + " before chatting.", location);
-			return;
+		var ageRestrictionHours = parseInt(getServerSetting("chatAgeRestriction"));
+		if(ageRestrictionHours > 0) {
+			var accountAge = Date.now() - user.date_joined;
+			var minimumAge = ageRestrictionHours * 60 * 60 * 1000;
+			if(accountAge < minimumAge) {
+				var timeRemaining = calculateTimeDiff(minimumAge - accountAge);
+				serverChatResponse("Your account is too new. You must wait " + timeRemaining + " before chatting.", location);
+				return;
+			}
 		}
 	}
 

--- a/frontend/templates/administrator.html
+++ b/frontend/templates/administrator.html
@@ -306,6 +306,10 @@
 					Global chat: prevent anonymous users:
 					<input type="checkbox" name="set_chat_global_no_anon" id="set_chat_global_no_anon"{%if global_chat_no_anon%} checked{%endif%}>
 				</div>
+				<div>
+					Required account age for chat (hours):
+					<input type="number" name="set_chat_age_restriction" id="set_chat_age_restriction" value="{{ chat_age_restriction }}" min="0" style="width: 60px;">
+				</div>
 				<input type="submit" value="Set">
 			</form>
 		</div>

--- a/runserver.js
+++ b/runserver.js
@@ -116,7 +116,8 @@ var sql_edits_init = "./backend/edits.sql";
 var serverSettings = {
 	announcement: "",
 	chatGlobalEnabled: "1",
-	chatGlobalNoAnon: "0"
+	chatGlobalNoAnon: "0",
+	chatAgeRestriction: "0"
 };
 var serverSettingsStatus = {};
 

--- a/runserver.js
+++ b/runserver.js
@@ -1322,10 +1322,11 @@ async function getUserInfo(cookies, is_websocket, dispatch) {
 			user = JSON.parse(s_data.session_data);
 			if(cookies.csrftoken == user.csrftoken) { // verify csrftoken
 				user.authenticated = true;
-				var userauth = (await db.get("SELECT level, is_active, email FROM auth_user WHERE id=?", user.id));
+				var userauth = (await db.get("SELECT level, is_active, email, date_joined FROM auth_user WHERE id=?", user.id));
 				var level = userauth.level;
 				user.is_active = !!userauth.is_active;
 				user.email = userauth.email;
+				user.date_joined = userauth.date_joined;
 
 				user.operator = level == 3;
 				user.superuser = level == 2 || level == 3;
@@ -1357,7 +1358,7 @@ async function getUserInfo(cookies, is_websocket, dispatch) {
 			var session = await uvias.get("SELECT * FROM accounts.get_session($1::bigint, $2::bytea)", [uid, session_id]);
 			if(session) {
 				// both guests and users are included
-				var user_account = await uvias.get("SELECT to_hex(uid) as uid, username, rank_id FROM accounts.users WHERE uid=$1::bigint", uid);
+				var user_account = await uvias.get("SELECT to_hex(uid) as uid, username, rank_id, created FROM accounts.users WHERE uid=$1::bigint", uid);
 				if(user_account) {
 					success = true;
 					var session_expire = session.expires.getTime();
@@ -1375,6 +1376,7 @@ async function getUserInfo(cookies, is_websocket, dispatch) {
 					user.authenticated = true;
 					user.display_username = user_account.username;
 					user.uv_rank = user_account.rank_id;
+					user.date_joined = user_account.created.getTime();
 					if(links_local) {
 						user.is_active = links_local.email_verified;
 						user.email = links_local.email;


### PR DESCRIPTION
Prevents newly created accounts from chatting until their account is at least x hours old. Helps mitigate evasion

> I can only assume it works on Uvias aswell, because I don't really have a good way to test it.

<img width="408" height="304" alt="image" src="https://github.com/user-attachments/assets/a3a06d30-263e-4ce1-a21c-f04aa252b7bd" />