### PR TITLE
Separate msg content and multiplier more clearly 

### DIFF
--- a/frontend/static/css/yourworld.css
+++ b/frontend/static/css/yourworld.css
@@ -119,6 +119,11 @@ a:visited {
 .message a {
 	color: blue;
 }
+.multiplier {
+	display: inline;
+	font-size: 10pt;
+	color: blue;
+}
 #loading {
 	font-family: Verdana;
 }

--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -1062,7 +1062,8 @@ function updateDuplicateChatGroup(chatGroup) {
 		}
 		data.msgDom.innerHTML = repeated.join("<br>");
 	} else {
-		data.msgDom.innerHTML = data.singleMessageHtml + " [x" + data.count + "]";
+		//data.msgDom.innerHTML = data.singleMessageHtml + " [x" + data.count + "]";
+		data.msgDom.innerHTML = data.singleMessageHtml + ' <div class="multiplier">[x' + data.count + ']</div>';
 	}
 }
 


### PR DESCRIPTION
Separate element for chat multiplier with different CSS
#264 
div class multiplier (inline), 10 pt font, blue 
<img width="214" height="28" alt="image" src="https://github.com/user-attachments/assets/e6da453d-427b-4e02-aae8-05d65b736f03" />
