### PR TITLE
Antibot

### DIFF
--- a/backend/utils/antibot.js
+++ b/backend/utils/antibot.js
@@ -2,7 +2,7 @@ var { obfuscate } = require("javascript-obfuscator");
 var fs = require("fs");
 var path = require("path");
 
-var settingsPath = path.resolve(process.cwd(), "nwotdata/settings.json");
+var settingsPath = path.resolve(process.cwd(), "../nwotdata/settings.json");
 if (!fs.existsSync(settingsPath)) { // Do I even need this?
     settingsPath = path.resolve(process.cwd(), "settings_example.json");
 }

--- a/backend/utils/antibot.js
+++ b/backend/utils/antibot.js
@@ -14,8 +14,6 @@ class Antibot {
 
     hash = Math.floor(Math.random() * 999);
 
-    verifiedDevices = false;
-
     constructor() {
         this.clientChecks = (settings.antibot && settings.antibot.client_checks) || [];
         this.botGlobals = (settings.antibot && settings.antibot.bot_globals) || [];
@@ -36,22 +34,37 @@ class Antibot {
     }
 
     verifyMessage(ws, data) {
+        if (!this.enabled) return false;
+        if (!ws.sdata) return false;
+
+        if (ws.sdata.antibot_verified) return false;
+
+        if (ws.sdata.user && (ws.sdata.user.operator || ws.sdata.user.superuser || ws.sdata.user.staff)) {
+            ws.sdata.antibot_verified = true;
+            return false;
+        }
+
+        if (data.kind == "antibot_response") {
+            if (this.verifyCode(data.code)) {
+                ws.sdata.antibot_verified = true;
+                return false;
+            }
+            return true;
+        }
+
+        return true;
+    }
+
+    sendChallenge(ws) {
         if (!this.enabled) return;
-
-        if (data.kind == "devices") {
-            this.verifiedDevices = true;
-        }
-
-        if (data.kind == "hi") {
-            if (ws.sdata && ws.sdata.user) {
-                var user = ws.sdata.user;
-                if (user.operator || user.superuser || user.staff) return false;
-            }
-
-            if (!data.code || !this.verifiedDevices || !this.verifyCode(data.code)) {
-                return true;
-            }
-        }
+        if (!ws.sdata) return;
+        var code = this.generateCode();
+        try {
+            ws.send(JSON.stringify({
+                kind: "antibot_challenge",
+                code: code
+            }));
+        } catch(e) {}
     }
 
     generateCode() {

--- a/backend/utils/antibot.js
+++ b/backend/utils/antibot.js
@@ -1,0 +1,86 @@
+var { obfuscate } = require("javascript-obfuscator");
+
+class Antibot {
+    clientChecks = []; //tbd
+
+    checkSolves = [];
+    solves = [];
+
+    hash = Math.floor(Math.random() * 999);
+
+    verifiedDevices = false;
+
+    constructor() {
+        for (let i = 0; i < 3; i++) {
+            this.solves.push(this.clientChecks[Math.floor(Math.random() * this.clientChecks.length)]);
+        }
+
+        for (let i = 0; i < this.solves.length; i++) {
+            this.checkSolves.push(Math.floor(Math.random() * 999) + "");
+        }
+    }
+
+    verifyMessage(ws, data) {
+        if (data.kind == "devices") {
+            this.verifiedDevices = true;
+        }
+
+        if (data.kind == "hi") {
+            if (ws.sdata && ws.sdata.user) {
+                var user = ws.sdata.user;
+                if (user.operator || user.superuser || user.staff) return false;
+            }
+
+            if (!data.code || !this.verifiedDevices || !this.verifyCode(data.code)) {
+                return true;
+            }
+        }
+    }
+
+    generateCode() {
+        let clientChecksCode = this.solves.map((z, i) => {
+            return `if(${z[0]} == ${JSON.stringify(z[1])}) parts.push("${this.checkSolves[i]}")`;
+        });
+
+        return obfuscate(
+            `
+                let parts = [];
+                ${clientChecksCode.join(";\n")}
+                return ${this.hash}*parts.map(z => z.split("").map(z => z.charCodeAt(0)).reduce((a, b)=>a+b)).reduce((a, b) => a + b);
+            `,
+            {
+                compact: true,
+                controlFlowFlattening: true,
+                controlFlowFlatteningThreshold: 1,
+                numbersToExpressions: true,
+                simplify: true,
+                stringArrayShuffle: true,
+                splitStrings: true,
+                stringArrayThreshold: 0.52,
+            },
+        ).getObfuscatedCode();
+    }
+
+    verifyCode(code) {
+        let solve = this.hash *
+            this.checkSolves.map((z) =>
+                z.split("").map((z) => z.charCodeAt(0)).reduce((a, b) => a + b)
+            ).reduce((a, b) => a + b);
+
+        if (solve !== code) {
+            console.log(
+                "Antibot failed! Code:",
+                code,
+                "Needed:",
+                solve,
+                "Hash:",
+                this.hash,
+                "Solves:",
+                this.solves,
+            );
+        }
+        return solve == code;
+    }
+}
+
+module.exports = Antibot;

--- a/backend/utils/antibot.js
+++ b/backend/utils/antibot.js
@@ -1,8 +1,14 @@
 var { obfuscate } = require("javascript-obfuscator");
+var fs = require("fs");
+var path = require("path");
+
+var settingsPath = path.resolve(process.cwd(), "nwotdata/settings.json");
+if (!fs.existsSync(settingsPath)) { // Do I even need this?
+    settingsPath = path.resolve(process.cwd(), "settings_example.json");
+}
+var settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
 
 class Antibot {
-    clientChecks = []; //tbd
-
     checkSolves = [];
     solves = [];
 
@@ -11,6 +17,8 @@ class Antibot {
     verifiedDevices = false;
 
     constructor() {
+        this.clientChecks = settings.antibot.client_checks;
+
         for (let i = 0; i < 3; i++) {
             this.solves.push(this.clientChecks[Math.floor(Math.random() * this.clientChecks.length)]);
         }

--- a/backend/utils/antibot.js
+++ b/backend/utils/antibot.js
@@ -18,8 +18,9 @@ class Antibot {
 
     constructor() {
         this.clientChecks = (settings.antibot && settings.antibot.client_checks) || [];
+        this.botGlobals = (settings.antibot && settings.antibot.bot_globals) || [];
 
-        if (!this.clientChecks.length) {
+        if (!this.clientChecks.length && !this.botGlobals.length) {
             this.enabled = false;
             return;
         }
@@ -59,9 +60,14 @@ class Antibot {
             return `if(${z[0]} == ${JSON.stringify(z[1])}) parts.push("${this.checkSolves[i]}")`;
         });
 
+        let botGlobalsCode = this.botGlobals.map((g) => {
+            return `if(typeof ${g} !== "undefined") return 0`;
+        });
+
         return obfuscate(
             `
                 let parts = [];
+                ${botGlobalsCode.join(";\n")}
                 ${clientChecksCode.join(";\n")}
                 return ${this.hash}*parts.map(z => z.split("").map(z => z.charCodeAt(0)).reduce((a, b)=>a+b)).reduce((a, b) => a + b);
             `,

--- a/backend/utils/antibot.js
+++ b/backend/utils/antibot.js
@@ -17,7 +17,13 @@ class Antibot {
     verifiedDevices = false;
 
     constructor() {
-        this.clientChecks = settings.antibot.client_checks;
+        this.clientChecks = (settings.antibot && settings.antibot.client_checks) || [];
+
+        if (!this.clientChecks.length) {
+            this.enabled = false;
+            return;
+        }
+        this.enabled = true;
 
         for (let i = 0; i < 3; i++) {
             this.solves.push(this.clientChecks[Math.floor(Math.random() * this.clientChecks.length)]);
@@ -29,6 +35,8 @@ class Antibot {
     }
 
     verifyMessage(ws, data) {
+        if (!this.enabled) return;
+
         if (data.kind == "devices") {
             this.verifiedDevices = true;
         }
@@ -46,6 +54,7 @@ class Antibot {
     }
 
     generateCode() {
+        if (!this.enabled) return null;
         let clientChecksCode = this.solves.map((z, i) => {
             return `if(${z[0]} == ${JSON.stringify(z[1])}) parts.push("${this.checkSolves[i]}")`;
         });
@@ -70,6 +79,7 @@ class Antibot {
     }
 
     verifyCode(code) {
+        if (!this.enabled) return true;
         let solve = this.hash *
             this.checkSolves.map((z) =>
                 z.split("").map((z) => z.charCodeAt(0)).reduce((a, b) => a + b)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "OurWorldOfText server",
 	"dependencies": {
 		"adm-zip": "^0.5.16",
+		"javascript-obfuscator": "^5.5.0",
 		"nodemailer": "^7.0.10",
 		"pg": "^8.13.1",
 		"sqlite3": "^5.1.7",

--- a/runserver.js
+++ b/runserver.js
@@ -27,6 +27,7 @@ const utils        = require("./backend/utils/utils.js");
 const rate_limiter = require("./backend/utils/rate_limiter.js");
 const ipaddress    = require("./backend/framework/ipaddress.js");
 const prompt       = require("./backend/utils/prompt.js");
+const Antibot      = require("./backend/utils/antibot.js");
 const restrictions = require("./backend/utils/restrictions.js");
 const frameUtils   = require("./backend/framework/utils.js");
 const serverUtil   = require("./backend/framework/server.js");
@@ -873,9 +874,6 @@ function setupHTTPServer() {
 async function initializeServer() {
 	console.log("Starting server...");
 
-	var antibotEnabled = settings.antibot && settings.antibot.client_checks && settings.antibot.client_checks.length;
-	console.log("Antibot",  (antibotEnabled ? "enabled" : "disabled"));
-
 	if(accountSystem == "uvias") {
 		setupUvias();
 		await uvias_init();
@@ -902,6 +900,14 @@ async function initializeServer() {
 
 	global_data.checkCSRF = httpServer.checkCSRF;
 	global_data.createCSRF = httpServer.createCSRF;
+
+	var antibot = new Antibot();
+	if(antibot.enabled) {
+		console.log("Antibot enabled (" + antibot.clientChecks.length + " checks, " + antibot.botGlobals.length + " bot globals)");
+	} else {
+		console.log("Antibot disabled");
+	}
+	global_data.antibot = antibot;
 
 	if(accountSystem == "local") {
 		await loadEmail();
@@ -2307,6 +2313,7 @@ async function manageWebsocketConnection(ws, req) {
 			}
 			return send_ws(JSON.stringify(res)); 
 		}
+		if(global_data.antibot.verifyMessage(ws, msg)) return;
 		// Begin calling a websocket function for the necessary request
 		if(!websockets.hasOwnProperty(kind)) {
 			return;

--- a/runserver.js
+++ b/runserver.js
@@ -873,6 +873,9 @@ function setupHTTPServer() {
 async function initializeServer() {
 	console.log("Starting server...");
 
+	var antibotEnabled = settings.antibot && settings.antibot.client_checks && settings.antibot.client_checks.length;
+	console.log("Antibot",  (antibotEnabled ? "enabled" : "disabled"));
+
 	if(accountSystem == "uvias") {
 		setupUvias();
 		await uvias_init();

--- a/runserver.js
+++ b/runserver.js
@@ -2248,6 +2248,8 @@ async function manageWebsocketConnection(ws, req) {
 		initial_user_count
 	}));
 
+	global_data.antibot.sendChallenge(ws);
+
 	if(client_cursor_pos[world.id]) {
 		var world_cursors = client_cursor_pos[world.id];
 		for(var csr_channel in world_cursors) {

--- a/settings_example.json
+++ b/settings_example.json
@@ -63,9 +63,5 @@
 		"display_email": "\"Our World of Text\" <email@site.com>"
 	},
 
-	"activation_key_days_expire": 3,
-
-	"antibot": {
-		"client_checks": []
-	}
+	"activation_key_days_expire": 3
 }

--- a/settings_example.json
+++ b/settings_example.json
@@ -63,5 +63,9 @@
 		"display_email": "\"Our World of Text\" <email@site.com>"
 	},
 
-	"activation_key_days_expire": 3
+	"activation_key_days_expire": 3,
+
+	"antibot": {
+		"client_checks": []
+	}
 }


### PR DESCRIPTION
Earlier today I was given access to `Antibot.ts` from https://multiplayerpiano.net. So, I rewrote it for compatibility within NodeWorldOfText. To circumvent the issue of AI-indexing and overall reverse-engineering, I came up with the idea to put the `client_checks` and `bot_globals` in `nwotdata/settings.json`. As you may notice, these arrays are not in `settings_example.json`. This is intentional. I have made it so that if the `antibot` object is not written into `nwotdata/settings.json`, the antibot is disabled. This also gives fork maintainers more freedom per instance.

How it works (as of now): when a client connects, the server sends an obfuscated JavaScript challenge (todo: change module) (`antibot_challenge`) containing 3 randomly-selected browser environment checks (from `client_checks`) and all automation-tool detection checks (from `bot_globals`). The client must eval the code in a browser context (bot globals cause it to return 0, fail) while passing client checks contributes to a hash that gets sent back as an `antibot_response`. The server verifies the hash matches. if it does, the connection is marked verified and all subsequent msgs pass through, otherwise every msg is dropped.

Todo: 
- [ ] Antibot whitelists, allowing certain connections (@system2k, do you think that the whitelists should be by token, user, or what?) to pass through without being checked