### PR TITLE
socket limit as a configurable option

### DIFF
--- a/backend/pages/admin/administrator.js
+++ b/backend/pages/admin/administrator.js
@@ -87,7 +87,8 @@ module.exports.GET = async function(req, write, server, ctx, params) {
 		client_version: getClientVersion(),
 		csrftoken,
 		global_chat_enabled: getServerSetting("chatGlobalEnabled") == "1",
-		global_chat_no_anon: getServerSetting("chatGlobalNoAnon") == "1"
+		global_chat_no_anon: getServerSetting("chatGlobalNoAnon") == "1",
+		sockets_per_ip: getServerSetting("socketsPerIp")
 	};
 
 	write(render("administrator.html", data));
@@ -142,6 +143,9 @@ module.exports.POST = async function(req, write, server, ctx) {
 			}
 		} else {
 			updateServerSetting("chatGlobalNoAnon", "0");
+		}
+		if("sockets_per_ip" in post_data) {
+			updateServerSetting("socketsPerIp", post_data.sockets_per_ip.toString());
 		}
 	}
 	if("announcement" in post_data) {

--- a/frontend/templates/administrator.html
+++ b/frontend/templates/administrator.html
@@ -306,6 +306,10 @@
 					Global chat: prevent anonymous users:
 					<input type="checkbox" name="set_chat_global_no_anon" id="set_chat_global_no_anon"{%if global_chat_no_anon%} checked{%endif%}>
 				</div>
+				<div>
+					Connections per IP:
+					<input type="text" name="sockets_per_ip" id="sockets_per_ip" value="{{ sockets_per_ip }}" style="width: 100%;">
+				</div>
 				<input type="submit" value="Set">
 			</form>
 		</div>

--- a/runserver.js
+++ b/runserver.js
@@ -116,7 +116,8 @@ var sql_edits_init = "./backend/edits.sql";
 var serverSettings = {
 	announcement: "",
 	chatGlobalEnabled: "1",
-	chatGlobalNoAnon: "0"
+	chatGlobalNoAnon: "0",
+	socketsPerIp: "50"
 };
 var serverSettingsStatus = {};
 
@@ -137,7 +138,6 @@ var isStopping = false;
 var closed_client_limit = 1000 * 60 * 20; // 20 min
 var ws_req_per_second = 1000;
 var pw_encryption = "sha512WithRSAEncryption";
-var connections_per_ip = 50;
 var static_path = "./frontend/static/";
 var static_path_web = "static/";
 var templates_path = "./frontend/templates/";
@@ -1467,6 +1467,7 @@ async function updateServerSetting(option, value) {
 	if(serverSettingsStatus[option].updating) return false;
 	serverSettingsStatus[option].updating = true;
 	serverSettings[option] = value;
+	if(option == "socketsPerIp"){connections_per_ip = parseInt(value)};
 	var element = await db.get("SELECT value FROM server_info WHERE name=?", option);
 	if(!element) {
 		await db.run("INSERT INTO server_info values(?, ?)", [option, value]);
@@ -1482,7 +1483,7 @@ function getServerSetting(option) {
 	}
 	return serverSettings[option];
 }
-
+var connections_per_ip = parseInt(getServerSetting("socketsPerIp"));
 async function modifyAnnouncement(text) {
 	if(typeof text != "string") return false;
 	updateServerSetting("announcement", text);

--- a/runserver.js
+++ b/runserver.js
@@ -1483,7 +1483,7 @@ function getServerSetting(option) {
 	}
 	return serverSettings[option];
 }
-var connections_per_ip = parseInt(getServerSetting("socketsPerIp"));
+
 async function modifyAnnouncement(text) {
 	if(typeof text != "string") return false;
 	updateServerSetting("announcement", text);
@@ -2288,7 +2288,7 @@ async function manageWebsocketConnection(ws, req) {
 		}
 	}
 }
-
+var connections_per_ip;
 async function start_server() {
 	await loadServerSettings();
 	loadRestrictionsList();
@@ -2349,7 +2349,7 @@ async function start_server() {
 		maxPayload: 128000
 	});
 	global_data.wss = wss;
-
+	connections_per_ip = parseInt(getServerSetting("socketsPerIp"));
 	wss.on("connection", async function(ws, req) {
 		try {
 			manageWebsocketConnection(ws, req);


### PR DESCRIPTION
tl;dr i got mildly annoyed that the limit of sockets per ip is hardcoded to 50, so i made these changes on my own nwot (+ world redirects), figured out how to push those changes without the world redirect changes, and made this pr. (branch name stands for "configurable socket limit, no world redirects")

how to use: go to admin panel. scroll until you find the new option (its below the "no anons in global" one). change it however you please.

use cases: during a proxy spam attack, it can be limited to, say, 3 per ip to allow for some legit usecases but lessen the proxy spam.

i know alan is implementing an anti-ddos too (hate on me all you want for the pr, but i think this could be a good change), but tbh i feel like it'd be easier to be able to configure stuff like this in the admin panel.